### PR TITLE
关于播放条、播放控制按钮在拖动后、音乐播放结束后的修复

### DIFF
--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -325,7 +325,9 @@ void BottomWidget::onSliderSongReleased()
     AdjustingPos = false;
     musicPlayer->seek(posAdjust);
     qDebug()<<"musicPlayer->state(): "<<musicPlayer->state();
-    setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
+    if(musicPlayer->state() == MusicPlayer::PlayingState){
+        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
+    }
 }
 
 void BottomWidget::onSoundToggle(bool mute)

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -335,10 +335,6 @@ void BottomWidget::onSliderSongReleased()
 
     AdjustingPos = false;
     musicPlayer->seek(posAdjust);
-    qDebug()<<"musicPlayer->state(): "<<musicPlayer->state();
-//    if(musicPlayer->state() == MusicPlayer::PlayingState){
-//        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
-//    }
 }
 
 void BottomWidget::onSoundToggle(bool mute)
@@ -417,7 +413,8 @@ void BottomWidget::onAudioFinished(bool isEndWithForce)
     setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_play.png\");}");
 }
 
-void BottomWidget::onAudioPlay(){
+void BottomWidget::onAudioPlay()
+{
     qDebug()<<"void BottomWidget::onAudioPlay()";
 
     setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -140,6 +140,8 @@ void BottomWidget::initConnection()
     connect(musicPlayer, SIGNAL(durationChanged(qint64)),this,SLOT(durationChanged(qint64)));
     connect(musicPlayer, SIGNAL(errorOccur(int,QString)),this,SLOT(onErrorOccurs(int,QString)));
 
+    connect(musicPlayer, SIGNAL(audioFinish(bool)),this,SLOT(onAudioFinished(bool)));
+
     sliderSound->setValue(SettingManager::GetInstance().data().volume);
     nVolumeBeforeMute = sliderSound->value();
     bSliderSoundPress = false;
@@ -322,6 +324,8 @@ void BottomWidget::onSliderSongReleased()
 
     AdjustingPos = false;
     musicPlayer->seek(posAdjust);
+    qDebug()<<"musicPlayer->state(): "<<musicPlayer->state();
+    setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
 }
 
 void BottomWidget::onSoundToggle(bool mute)
@@ -393,6 +397,11 @@ void BottomWidget::onErrorOccurs(int code, QString strErr)
     Q_UNUSED(code)
     BesMessageBox::information(tr("提示"),
         tr("播放音频时发生错误，请尝试使用别的音频文件")+ "\n\n" + tr("出错细节:")+ strErr);
+}
+
+void BottomWidget::onAudioFinished(bool isEndWithForce)
+{
+    setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_play.png\");}");
 }
 
 

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -141,6 +141,8 @@ void BottomWidget::initConnection()
     connect(musicPlayer, SIGNAL(errorOccur(int,QString)),this,SLOT(onErrorOccurs(int,QString)));
 
     connect(musicPlayer, SIGNAL(audioFinish(bool)),this,SLOT(onAudioFinished(bool)));
+    connect(musicPlayer, SIGNAL(audioPlay()),this,SLOT(onAudioPlay()));
+    connect(musicPlayer, SIGNAL(audioPause()),this,SLOT(onAudioPause()));
 
     sliderSound->setValue(SettingManager::GetInstance().data().volume);
     nVolumeBeforeMute = sliderSound->value();
@@ -151,24 +153,30 @@ void BottomWidget::initConnection()
 
 void  BottomWidget::reloadMusic(QString musicPath)
 {
+    qDebug()<<"void  BottomWidget::reloadMusic(QString="<<musicPath<<")+musicPlayer->state()="<<musicPlayer->state();
+
     if(musicPlayer->state() != MusicPlayer::StoppedState )
         musicPlayer->stop();
 
     musicPlayer->setMusicPath(musicPath);
 
-    if(musicPlayer->state() == MusicPlayer::PlayingState)
-        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
-    else
-        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_play.png\");}");
+//    不要在这里设置播放控制按钮的状态，而是用MusicPlayer的信号
+//    if(musicPlayer->state() == MusicPlayer::PlayingState)
+//        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
+//    else
+//        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_play.png\");}");
 }
 
 void BottomWidget::play()
 {
+    qDebug()<<"void BottomWidget::play() musicPlayer->getMusicPath()="<<musicPlayer->getMusicPath();
+
     if(musicPlayer->getMusicPath().size() != 0)
     {
         musicPlayer->play();
 
-        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
+//        不要在这里设置播放控制按钮的状态，而是用MusicPlayer的信号
+//        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
     }
 }
 
@@ -244,6 +252,7 @@ void BottomWidget::exitMakingMode()
 
 }
 
+//btnPlayAndPause->clicked(bool) emitted
 void BottomWidget::onPlayOrPause()
 {
     if(musicPlayer->state() == MusicPlayer::PlayingState)
@@ -327,9 +336,9 @@ void BottomWidget::onSliderSongReleased()
     AdjustingPos = false;
     musicPlayer->seek(posAdjust);
     qDebug()<<"musicPlayer->state(): "<<musicPlayer->state();
-    if(musicPlayer->state() == MusicPlayer::PlayingState){
-        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
-    }
+//    if(musicPlayer->state() == MusicPlayer::PlayingState){
+//        setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
+//    }
 }
 
 void BottomWidget::onSoundToggle(bool mute)
@@ -405,6 +414,19 @@ void BottomWidget::onErrorOccurs(int code, QString strErr)
 
 void BottomWidget::onAudioFinished(bool isEndWithForce)
 {
+    setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_play.png\");}");
+}
+
+void BottomWidget::onAudioPlay(){
+    qDebug()<<"void BottomWidget::onAudioPlay()";
+
+    setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
+}
+
+void BottomWidget::onAudioPause()
+{
+    qDebug()<<"void BottomWidget::onAudioPause()";
+
     setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_play.png\");}");
 }
 

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -268,6 +268,8 @@ void BottomWidget::durationChanged(qint64 duration)
 
 void BottomWidget::positionChanged(int position)
 {
+    qDebug()<<"void BottomWidget::positionChanged(int position="<<position<<")";
+
     if(!AdjustingPos)
     {
         int pecentOfThousand = musicPlayer->duration() == 0? 0: int(1.0 * position / musicPlayer->duration() * 1000);

--- a/BottomWidgets/BottomWidget.h
+++ b/BottomWidgets/BottomWidget.h
@@ -59,6 +59,9 @@ private slots:
 
     void onErrorOccurs(int code,QString strErr);
 
+    //
+    void onAudioFinished(bool isEndWithForce);
+
 private:
     bool bInMakingMode;     //标记是否在制作模式中
 

--- a/BottomWidgets/BottomWidget.h
+++ b/BottomWidgets/BottomWidget.h
@@ -61,6 +61,8 @@ private slots:
 
     //
     void onAudioFinished(bool isEndWithForce);
+    void onAudioPlay();
+    void onAudioPause();
 
 private:
     bool bInMakingMode;     //标记是否在制作模式中

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -891,6 +891,11 @@ void MusicPlayer::stop()
 //跳到时间点播放（单位 毫秒）
 void MusicPlayer::seek(quint64 pos)
 {
+    if(m_positionUpdateTimer.isActive())
+    {
+        m_positionUpdateTimer.stop();
+    }
+
     //先获得总长
     quint64 total = duration();
     if(pos > total)
@@ -899,6 +904,11 @@ void MusicPlayer::seek(quint64 pos)
     }
 
 	playThread->seekToPos(pos);
+
+    if(!m_positionUpdateTimer.isActive())
+    {
+        m_positionUpdateTimer.start();
+    }
 }
 
 //往后跳（单位 毫秒）

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -774,8 +774,8 @@ MusicPlayer::MusicPlayer(QObject* parent):QObject(parent),m_volume(128)
             Qt::BlockingQueuedConnection);
 
 
-    m_interval = 50;
-    m_positionUpdateTimer.setInterval(m_interval);
+//    m_interval = 50;
+//    m_positionUpdateTimer.setInterval(m_interval);
     connect(&m_positionUpdateTimer,SIGNAL(timeout()),this, SLOT(sendPosChangedSignal() ));
 
     m_position = 0;

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -600,7 +600,10 @@ void PlayThread::generateAudioDataLoop()
                AVRational aVRational = {1, 1000};
                int64_t res = av_rescale_q(millisecondToSeek ,aVRational,pFormatCtx->streams[audioStream]->time_base);
 
-               SDL_PauseAudio(1);
+//               不要直接调SDL_PauseAudio()，避免相应的信号发不出去
+//               SDL_PauseAudio(1);
+               pauseDevice();
+
                //block here
                if (av_seek_frame(m_MS.fct, audioStream, res, AVSEEK_FLAG_ANY) < 0)
                {
@@ -618,7 +621,9 @@ void PlayThread::generateAudioDataLoop()
                        packet_queue_flush(&m_MS.audioq); //清除队列
                    }
                }
-               SDL_PauseAudio(0);
+//               不要直接调SDL_PauseAudio()，避免相应的信号发不出去
+//               SDL_PauseAudio(0);
+               playDevice();
 
                 AGStatus = AGS_PLAYING;
         }


### PR DESCRIPTION
你好，我做了一些修改。

尝试修复的问题：

<br>

1. 播放时拖动 sliderSong 进行 seek 后，如果时间正好，sliderSong 会跳回当前播放的位置：

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/Entities/MusicPlayer/musicPlayer.cpp#L891-L902

<br>

<br>

1. 暂停时拖动 sliderSong 进行 seek 后会继续播放音乐，但 btnPlayAndPause 的样式并不会由“播放”变为“暂停”；

2. 音乐播放结束后 btnPlayAndPause 的样式不会由“暂停”变为“播放”；

3. btnPlayAndPause 的样式现在由 musicPlayer 发出的信号决定，而不是在切换状态的时直接修改：

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/BottomWidgets/BottomWidget.cpp#L157-L160

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/BottomWidgets/BottomWidget.cpp#L169

<br>

<br>

1. PlayThread 在进行 Seek 前后对音乐进行暂停和播放没有发出相应的信号：

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/Entities/MusicPlayer/musicPlayer.cpp#L603

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/Entities/MusicPlayer/musicPlayer.cpp#L621

<br>

<br>

1. MusicPlayer 构造函数中存在对 m_positionUpdateTimer 属性的设置，但在```BottomWidget::initEntity()```方法中有代码将其覆盖：

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/Entities/MusicPlayer/musicPlayer.cpp#L777-L778

https://github.com/BensonLaur/Beslyric-for-X/blob/81d51042e3e1273faeaca3002eb3f92cbd2b227e/BottomWidgets/BottomWidget.cpp#L117-L118

<br>

---

代码中留下了部分输出日志的代码，还有一些注释。

请仔细检查我的改动，谢谢。