### PR TITLE
支持"歌手 - 歌曲名"|“"歌曲名 - 歌手" 2 种命名方式保存文件；修复"下载歌词"页面按钮失效问题

### DIFF
--- a/BesWidgets/table/BesNcmSongTableView.cpp
+++ b/BesWidgets/table/BesNcmSongTableView.cpp
@@ -70,6 +70,14 @@ void BesNcmSongTableView::OnDownloadNcmMusic(SONGINFO songInfo)
         return;
     }
 
+    //构建本地文件路径
+    auto setting = SettingManager::GetInstance().data();
+    QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
+                            songInfo.strSong +" - "+ songInfo.strArtists
+                           :songInfo.strArtists +" - "+ songInfo.strSong;
+    QString strSavePath = setting.musicDowloadPath + '/' + localFileName + ".mp3";
+
+
     if(songInfo.nPercentage == -1) //只有从未下载过时，才尝试下载
     {
         emit sig_oneDownloadStarted();
@@ -78,8 +86,6 @@ void BesNcmSongTableView::OnDownloadNcmMusic(SONGINFO songInfo)
 
         QString strId = QString().number(songInfo.nID);
         QString strLink = "http://music.163.com/song/media/outer/url?id="+ strId +".mp3";
-        QString strSavePath = SettingManager::GetInstance().data().musicDowloadPath + '/'
-                +songInfo.strSong +"-"+ songInfo.strArtists + ".mp3";
 
         net.DownloadFile(strLink, strSavePath, songInfo.nID);
     }
@@ -91,9 +97,6 @@ void BesNcmSongTableView::OnDownloadNcmMusic(SONGINFO songInfo)
     else if(songInfo.nPercentage == 100)
     {
         //直接选择歌曲到制作页面，并自动跳转页面
-        QString strSavePath = SettingManager::GetInstance().data().musicDowloadPath + '/'
-                +songInfo.strSong +"-"+ songInfo.strArtists + ".mp3";
-
         emit sig_setMusicPathToMakingPage(strSavePath);
     }
 }

--- a/Entities/LyricSearcherFactory/ThreadSearchNcmMusic.h
+++ b/Entities/LyricSearcherFactory/ThreadSearchNcmMusic.h
@@ -17,7 +17,7 @@ class ThreadSearchNcmMusic :public QThread
 public:
     ThreadSearchNcmMusic():m_bIsSearching(false){}
 
-    void StartSearchLyric(QString artist, QString song)
+    void StartSearchNcm(QString artist, QString song)
     {
         QMutexLocker locker(&mutex);
 

--- a/Entities/SettingManager.cpp
+++ b/Entities/SettingManager.cpp
@@ -73,6 +73,7 @@ bool SettingManager::saveSettingData()
         writer.writeStartElement("musicDownload");
         writer.writeTextElement("path",settingData.musicDowloadPath);
         writer.writeTextElement("agreeDeclaration",QString().number(settingData.agreeDownloadDeclaration ? 1:0));
+        writer.writeTextElement("nameFormatStyle",QString().number((int)settingData.nameFormatStyle));
         writer.writeEndElement();
 
 
@@ -268,6 +269,10 @@ bool SettingManager::parseAll(QXmlStreamReader &reader)
                       else if (strElementName == "agreeDeclaration")
                       {
                           settingData.agreeDownloadDeclaration = reader.readElementText().toInt() == 1;
+                      }
+                      else if(strElementName == "nameFormatStyle")
+                      {
+                          settingData.nameFormatStyle = (NameFormatStyle)reader.readElementText().toInt();
                       }
                   }
                   else if(reader.isEndElement()) {

--- a/Entities/SettingManager.h
+++ b/Entities/SettingManager.h
@@ -11,6 +11,11 @@
 #include <QXmlStreamReader>
 #include <QXmlStreamWriter>
 
+enum NameFormatStyle{
+    ARTIST_SONG = 0,
+    SONG_ARTIST = 1
+};
+
 class SettingData
 {
 public:
@@ -26,6 +31,8 @@ public:
 
     bool loginAnonymously;
     bool autoCheckForUpgrade;
+
+    int nameFormatStyle;
 
     //程序运行过程用户操作保存
     QString machineCode;        //存储上次获取的设备相关的唯一标志，在设备更换时，需要重置 agreeDownloadDeclaration 等设置
@@ -43,6 +50,8 @@ public:
         agreeDownloadDeclaration = false;
         loginAnonymously = false;
         autoCheckForUpgrade = true;
+        nameFormatStyle = ARTIST_SONG;
+
         machineCode = "";
         skinName = "black";
         volume = 128;           //最大值128

--- a/Entities/SkinFactory/ISkin.h
+++ b/Entities/SkinFactory/ISkin.h
@@ -49,6 +49,7 @@ public:
         cssContent += GetQTableWidgetCss();
         cssContent += GetQListWidgetCss();
         cssContent += GetQCheckBoxCss();
+        cssContent += GetQRadioButtonCss();
 
         return cssContent;
     }
@@ -1121,6 +1122,33 @@ private:
           "}"
 
         ;
+        return str;
+    }
+
+    QString GetQRadioButtonCss()
+    {
+        QString str = ""
+                "QRadioButton::indicator {   "
+"                   width: 14px;   "
+"                   height: 14px;   "
+                "}"
+                "QRadioButton::indicator::unchecked {"
+"                    width: 14px;"
+"                    margin-top: -5px;"
+"                    margin-bottom: -5px;"
+"                    border-radius: 7px;"
+"                    border: 1px solid rgba(100, 100, 100, 100);"
+"                    background: qradialgradient(spread:pad, cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5,stop:0.25 "+bottomContainerColor+", stop:0.5 "+bottomContainerColor+");"
+                "}"
+                "QRadioButton::indicator::checked {"
+"                    width: 14px;"
+"                    margin-top: -5px;"
+"                    margin-bottom: -5px;"
+"                    border-radius: 7px;"
+"                    border: 1px solid rgba(100, 100, 100, 100);"
+"                    background: qradialgradient(spread:pad, cx:0.5, cy:0.5, radius:0.5, fx:0.5, fy:0.5,stop:0.25 "+baseColor+",stop:0.4 "+baseColor+", stop:0.5 "+bottomContainerColor+");"
+                "}"
+                ;
         return str;
     }
 

--- a/Entities/ThreadGuessLyricInfo.h
+++ b/Entities/ThreadGuessLyricInfo.h
@@ -75,8 +75,7 @@ protected:
             }
         }
 
-        assert( nLastDot != -1 && nLastSlash != -1 && "音乐路径出错");
-
+        //assert( nLastDot != -1 && nLastSlash != -1 && "音乐路径出错");
         if(nLastDot == -1 || nLastSlash == -1)
         {
             //没有结果，直接发送原路径出去

--- a/MiddleWidgets/SettingWidget/SuMusicDownload.cpp
+++ b/MiddleWidgets/SettingWidget/SuMusicDownload.cpp
@@ -15,7 +15,7 @@ QString SuMusicDownload::getName()
 
 int SuMusicDownload::getUnitHeight()
 {
-   return 230* BesScaleUtil::mscale();
+   return 340* BesScaleUtil::mscale();
 }
 
 QWidget *SuMusicDownload::getUnitWidget(QWidget *parent)
@@ -51,6 +51,23 @@ QWidget *SuMusicDownload::getUnitWidget(QWidget *parent)
     checkboxMusicDownload = new QCheckBox(SettingUnitContainer);
     checkboxMusicDownload->setText(tr("我已查看并同意《 BesLyric 音乐下载声明 》 "));
 
+    labelNameFormat = new QLabel(SettingUnitContainer);
+    labelNameFormat->setText(tr("命名格式："));
+    labelNameFormat->setMinimumHeight(30* BesScaleUtil::mscale());
+    labelNameFormat->setMaximumHeight(30* BesScaleUtil::mscale());
+    radioFormatArtistSong = new QRadioButton(tr("歌手 - 歌曲名"));
+    radioFormatSongArtist = new QRadioButton(tr("歌曲名 - 歌手"));
+    radioFormatArtistSong->setMinimumHeight(30* BesScaleUtil::mscale());
+    radioFormatArtistSong->setMaximumHeight(30* BesScaleUtil::mscale());
+    radioFormatSongArtist->setMinimumHeight(30* BesScaleUtil::mscale());
+    radioFormatSongArtist->setMaximumHeight(30* BesScaleUtil::mscale());
+    groupNameFormat = new QButtonGroup(SettingUnitContainer);
+
+    groupNameFormat->addButton(radioFormatArtistSong, ARTIST_SONG);
+    groupNameFormat->addButton(radioFormatSongArtist, SONG_ARTIST);
+    SettingManager::GetInstance().data().nameFormatStyle == NameFormatStyle::SONG_ARTIST?
+    radioFormatSongArtist->setChecked(true):radioFormatArtistSong->setChecked(true);
+
     QHBoxLayout* hLayout2 = new QHBoxLayout();
     hLayout2->addWidget(btnSelectMusicDownloadPath);
     hLayout2->addWidget(labelMusicDownloadPathTip);
@@ -60,13 +77,24 @@ QWidget *SuMusicDownload::getUnitWidget(QWidget *parent)
     hLayout3->addWidget(checkboxMusicDownload);
     hLayout3->addSpacerItem(new QSpacerItem(20* BesScaleUtil::mscale(),20, QSizePolicy::MinimumExpanding ,QSizePolicy::Fixed));
 
+    QVBoxLayout* vLayout4 = new QVBoxLayout();
+    vLayout4->addWidget(labelNameFormat);
+    vLayout4->addWidget(radioFormatArtistSong);
+    vLayout4->addWidget(radioFormatSongArtist);
+
+    QHBoxLayout* hLayout4 = new QHBoxLayout();
+    hLayout4->addLayout(vLayout4);
+    hLayout4->addSpacerItem(new QSpacerItem(20* BesScaleUtil::mscale(),20, QSizePolicy::MinimumExpanding ,QSizePolicy::Minimum));
+
     QVBoxLayout* vLayout = new QVBoxLayout(SettingUnitContainer);
     vLayout->setSpacing(15);
     vLayout->addLayout(hLayout1);
     vLayout->addLayout(hLayout2);
     vLayout->addSpacerItem(new QSpacerItem(20,15* BesScaleUtil::mscale(), QSizePolicy::Fixed ,QSizePolicy::Fixed));
     vLayout->addLayout(hLayout3);
-    vLayout->addSpacerItem(new QSpacerItem(20,20* BesScaleUtil::mscale(), QSizePolicy::Fixed ,QSizePolicy::MinimumExpanding));
+    vLayout->addSpacerItem(new QSpacerItem(20,15* BesScaleUtil::mscale(), QSizePolicy::Fixed ,QSizePolicy::Fixed));
+    vLayout->addLayout(hLayout4);
+    vLayout->addSpacerItem(new QSpacerItem(20,40* BesScaleUtil::mscale(), QSizePolicy::Fixed ,QSizePolicy::MinimumExpanding));
 
     //如果不同意下载声明，下载路径置空
     if(!SettingManager::GetInstance().data().agreeDownloadDeclaration)
@@ -220,6 +248,7 @@ QWidget *SuMusicDownload::getUnitWidget(QWidget *parent)
 
     });
 
+    connect(groupNameFormat, SIGNAL(buttonClicked(int)),this, SLOT(OnNameFormatClicked(int)));
 
     return SettingUnitContainer;
 }
@@ -344,4 +373,21 @@ QString SuMusicDownload::getTipForClickCount(int count, qint64 currentTime)
     }
 
     return strReturn;
+}
+
+
+void SuMusicDownload::OnNameFormatClicked(int radioId)
+{
+    int backup = SettingManager::GetInstance().data().nameFormatStyle;
+    SettingManager::GetInstance().data().nameFormatStyle = (NameFormatStyle)radioId;
+
+    if(!SettingManager::GetInstance().saveSettingData())
+    {
+        SettingManager::GetInstance().data().nameFormatStyle = backup;
+
+        backup == NameFormatStyle::SONG_ARTIST?
+            radioFormatSongArtist->setChecked(true):radioFormatArtistSong->setChecked(true);
+
+        BesMessageBox::information(tr("提示"),tr("本次设置保存失败，可能是程序没有写权限"));
+    }
 }

--- a/MiddleWidgets/SettingWidget/SuMusicDownload.h
+++ b/MiddleWidgets/SettingWidget/SuMusicDownload.h
@@ -4,11 +4,15 @@
 #include <QObject>
 #include <QLabel>
 #include <QCheckBox>
+#include <QRadioButton>
+#include <QButtonGroup>
 #include "BesButton.h"
 #include "ISettingUnit.h"
 
 class SuMusicDownload: public ISettingUnit
 {
+    Q_OBJECT
+
 public:
     virtual QString getName() override;
     virtual int getUnitHeight() override;
@@ -18,6 +22,9 @@ private:
     virtual QString getTipAfterAgreeForTimes(int);
 
     virtual QString getTipForClickCount(int count, qint64 currentTime);
+
+private slots:
+    void OnNameFormatClicked(int radioId);
 
 public:
     QWidget* SettingUnitContainer;
@@ -29,6 +36,11 @@ public:
     QLabel*  labelMusicDownloadPath;
 
     QCheckBox*  checkboxMusicDownload;
+
+    QLabel* labelNameFormat;
+    QRadioButton* radioFormatArtistSong;
+    QRadioButton* radioFormatSongArtist;
+    QButtonGroup* groupNameFormat;
 };
 
 #endif // SuMusicDownload_H

--- a/MiddleWidgets/SubPageDownloadLyric.cpp
+++ b/MiddleWidgets/SubPageDownloadLyric.cpp
@@ -281,6 +281,8 @@ void SubPageDownloadLyric::initConnection()
     connect(btnRawLyricPanelSelect, SIGNAL(clicked(bool)),this, SLOT(OnSelectRawLyricSavePath()));
     connect(btnRawLyricPanelSave, SIGNAL(clicked(bool)),this, SLOT(OnSaveRawLyric()));
 
+    connect(btnLrcLyricPanelSelect, SIGNAL(clicked(bool)),this, SLOT(OnSelectLrcLyricSavePath()));
+    connect(btnLrcLyricPanelSave, SIGNAL(clicked(bool)),this, SLOT(OnSaveLrcLyric()));
 }
 
 void SubPageDownloadLyric::OnSearchInProgram()
@@ -504,8 +506,12 @@ void SubPageDownloadLyric::OnSaveRawLyric()
     if(artist.size() == 0)
         artist = "XXX";
 
-    fileName = editRawLyricPanelSavePath->text() + "/"
-            + song + " - " + artist + ".txt";
+    //构建本地文件路径
+    auto setting = SettingManager::GetInstance().data();
+    QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
+                            song +" - "+ artist
+                           :artist +" - "+ song;
+    fileName = editRawLyricPanelSavePath->text() + "/" + localFileName + ".txt";
 
     //提示是否保存到路径
     if(QMessageBox::StandardButton::Ok ==
@@ -536,7 +542,7 @@ void SubPageDownloadLyric::OnSaveRawLyric()
     }
 }
 
-void SubPageDownloadLyric::OnSavectLrcLyric()
+void SubPageDownloadLyric::OnSaveLrcLyric()
 {
     //检查保存路径和是否有要保存的内容
     if(editLrcLyricPanelSavePath->text().size() == 0)
@@ -575,8 +581,12 @@ void SubPageDownloadLyric::OnSavectLrcLyric()
     if(artist.size() == 0)
         artist = "XXX";
 
-    fileName = editLrcLyricPanelSavePath->text() + "/"
-            + song + " - " + artist + ".lrc";
+    //构建本地文件路径
+    auto setting = SettingManager::GetInstance().data();
+    QString localFileName = setting.nameFormatStyle==SONG_ARTIST?
+                            song +" - "+ artist
+                           :artist +" - "+ song;
+    fileName = editLrcLyricPanelSavePath->text() + "/" + localFileName + ".lrc";
 
     //提示是否保存到路径
     if(QMessageBox::StandardButton::Ok ==

--- a/MiddleWidgets/SubPageDownloadLyric.h
+++ b/MiddleWidgets/SubPageDownloadLyric.h
@@ -40,7 +40,7 @@ public slots:
     void OnSelectRawLyricSavePath();
     void OnSelectLrcLyricSavePath();
     void OnSaveRawLyric();
-    void OnSavectLrcLyric();
+    void OnSaveLrcLyric();
 
 public:
     void searchLyricDirectly(const QString& artists, const QString& song);

--- a/MiddleWidgets/SubPageDownloadSong.cpp
+++ b/MiddleWidgets/SubPageDownloadSong.cpp
@@ -169,7 +169,7 @@ void SubPageDownloadSong::OnSearchSong()
     labelNcmSongResultTip5->setText(tr("正在搜索中..."));
     btnSearchNcmSong->setEnabled(false);
 
-    searchThread.StartSearchLyric(artist, song);
+    searchThread.StartSearchNcm(artist, song);
 }
 
 void SubPageDownloadSong::OnSongResultChanged(LyricSearchResult result)


### PR DESCRIPTION
1、实现 issue #9 希望支持切换文件名命名格式 功能，支持"歌手 - 歌曲名"|“"歌曲名 - 歌手" 2 种命名方式的切换
2、修复"下载歌词"页面"LRC歌词"面板中"选择“"和"保存LRC歌词"失效问题