### PR TITLE
修复有关播放条的问题，整理部分界面逻辑

### DIFF
--- a/BottomWidgets/BottomWidget.h
+++ b/BottomWidgets/BottomWidget.h
@@ -92,6 +92,8 @@ private:
 
     bool AdjustingPos;
     quint64 posAdjust;
+
+    int sliderSongOriginalPos; //sliderSong被按下时的位置
 };
 
 #endif // BOTTOMWIDGET_H

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -276,6 +276,7 @@ signals:
 public slots:
     //播放控制
     void reload();                   //stop() 并 play();
+    void playAndPause();
     void play();
     void pause();
     void stop();


### PR DESCRIPTION
对 #13 中提到的部分问题的修复，在 BottomWidget::onSliderSongPressed()、BottomWidget::onSliderSongMoved(int) 和 BottomWidget::onSliderSongReleased() 三个方法中进行了修改：

1. 不播放任何歌曲，拖动并释放 sliderSong 会执行 musicPlayer->seek(posAdjust)：

对 AdjustingPos 的赋值和判定进行重写，AdjustingPos 的值现在由 bInMakingMode 和 musicPlayer->state() 决定，而 AdjustingPos 决定最终是否执行 musicPlayer->seek(posAdjust)；

2. 在播放时单击或长按 sliderSong（不拖动），可能会使 sliderSong 回退到之前的某个时刻：

添加成员变量 sliderSongOriginalPos 记录 sliderSong 在 BottomWidget::onSliderSongPressed() 时的位置，在 BottomWidget::onSliderSongReleased() 时将 sliderSong 的当前值与 sliderSongOriginalPos 比较，相同则不执行 musicPlayer->seek(posAdjust)；

<br>

整理的逻辑：

1. 移除 BottomWidget 中除了 onAudioFinished(bool)、onAudioPlay() 和 onAudioPause() 中的对 btnPlayAndPause 样式的修改（包括之前注释掉的），也移除了相关的判定；

2. 切换播放暂停状态的代码从 BottomWidget  移动到 MusicPlayer::playAndPause() 中：

``` CPP
void MusicPlayer::playAndPause(){
    qDebug()<<"void MusicPlayer::playAndPause() bIsLock="<<bIsLock;

    if(getMusicPath().size() != 0){
        if(state()==PlayingState){
            pause();
        }else{
            play();
        }
        // StoppedState
    }
}
```

3. 在 MusicPlayer::pause() 方法中添加对于 m_positionUpdateTimer 的判断，使 m_positionUpdateTimer 在暂停播放时不工作；

<br>

---

代码中留下了输出日志的代码和注释。

请仔细检查我的改动，谢谢。

