### PR TITLE
修复含有“.”的歌曲文件的文件名不能被正确识别

### DIFF
--- a/Entities/MP3Editor/mp3Editor.cpp
+++ b/Entities/MP3Editor/mp3Editor.cpp
@@ -317,7 +317,7 @@ void ConvertThread::buildOptionContent(OptionParseContext *octx)
      if(customData.mp3OutputPath.isEmpty())
      {
          QFileInfo fileInfo(inputMp3Path);
-         outputMp3Path = fileInfo.dir().absolutePath()+"/"+fileInfo.baseName()+"-converted.mp3";
+         outputMp3Path = fileInfo.dir().absolutePath()+"/"+fileInfo.completeBaseName()+"-converted.mp3";
      }
      else
      {

--- a/MiddleWidgets/MiddleWidget.cpp
+++ b/MiddleWidgets/MiddleWidget.cpp
@@ -176,7 +176,7 @@ void MiddleWidget::geometryAnimationFinish()
 void MiddleWidget::onReloadMusic(QString musicFileNamePath)
 {
     QFileInfo fileinfo(musicFileNamePath);
-    onSetMusicTitle(fileinfo.baseName());
+    onSetMusicTitle(fileinfo.completeBaseName());
     onSetMusicArtist("");                   //重载时，歌手未知
 
     pagePreviewLyric->setToDefaultAlbumImage();

--- a/MiddleWidgets/SubPageMaking.cpp
+++ b/MiddleWidgets/SubPageMaking.cpp
@@ -559,7 +559,7 @@ void SubPageMaking::finishMaking()
         else
         {
             QFileInfo musicFile(pathMusic);
-            QString outputFile = pathOutputDir + "/" + musicFile.baseName() + ".lrc";
+            QString outputFile = pathOutputDir + "/" + musicFile.completeBaseName() + ".lrc";
 
             if(lyricMaker.saveLyrc(outputFile))
             {


### PR DESCRIPTION
使用 QFileInfo::completeBaseName() 而不是 QFileInfo::baseName()，避免文件名在第一个“.”处结束。

https://doc.qt.io/qt-5/qfileinfo.html#completeBaseName