### PR TITLE
改进 sliderSong 的点击、拖拽与同步问题

### DIFF
--- a/BesWidgets/BesSlider.h
+++ b/BesWidgets/BesSlider.h
@@ -14,19 +14,10 @@ class BesSlider :public QSlider
 {
     Q_OBJECT
 public:
-//    BesSlider(QWidget* parent = Q_NULLPTR, int handleWidth = 30):QSlider(parent),handleWidthValue(handleWidth){}
     BesSlider(QWidget* parent = Q_NULLPTR):QSlider(parent){
         setStyle(new BesSliderStyle(this->style()));
         setMouseTracking(true);// 为了鼠标在 sliderSong 上方（不单击）移动时触发 mouseMoveEvent 以显示正确的鼠标形状
     }
-
-    //覆盖 QAbstractSlider::setRange,为了记录范围，判断单前点击的是不是在handle上
-//    void setRange(int min, int max)
-//    {
-//        QAbstractSlider::setRange(min, max);
-//        minValue = min;
-//        maxValue = max;
-//    }
 
     //是否启用鼠标事件响应
     void enableMouseEvent(bool enable)
@@ -105,52 +96,12 @@ protected:
         }
 
         QSlider::mousePressEvent(ev); //在这之后，手柄移动到了点击的位置，value() 也变为点击处的值，所以任何判断都要在之前进行
-
-        //刷新当前位置
-        // 在这里执行没有意义，&QSlider::sliderPressed 的接收者也无法做更多的工作，所以放到 mouseReleaseEvent(ev) 中发送
-//        emit sig_refreshClickPos(value());
-
-        //注意应先调用父类的鼠标点击处理事件，这样可以不影响拖动的情况
-//        QSlider::mousePressEvent(ev); //这会造成移动，之后拿到的value()都是移动后的
-
-        //获取鼠标的位置，这里并不能直接从ev中取值（因为如果是拖动的话，鼠标开始点击的位置没有意义了）
-//        double posPercent = ev->pos().x() / (double)width();
-
-//        int pos = minValue + (int)((maxValue-minValue)* posPercent);
-//        int curValue = value();
-//        if(pos  < curValue - handleWidthValue/2 || pos  > curValue + handleWidthValue/2)
-//        {
-            //发送自定义的鼠标单击信号
-//            emit sig_clickNotOnHandle(pos);
-//        }
     }
-
-//    virtual void enterEvent(QEvent *event)
-//    {
-//        if(enableMouseEvt)
-//        {
-//            setCursor(QCursor(Qt::PointingHandCursor));
-//            QSlider::enterEvent(event);
-//        }
-//        else
-//            setCursor(QCursor(Qt::ArrowCursor));
-//    }
-
-//    virtual void leaveEvent(QEvent *event)
-//    {
-//        unsetCursor();
-
-//        if(enableMouseEvt)
-//            QSlider::leaveEvent(event);
-//    }
 
 signals:
     void sig_refreshClickPos(int pos);
 
 private:
-//    int minValue = 0;
-//    int maxValue = 0;
-//    double handleWidthValue = 30; //滑块handle的大小，这个取值会作为 sig_clickNotOnHandle 发送时判断是否在handle之外的依据
     bool enableMouseEvt = false;  //默认禁用
 
     QPoint oldPos;

--- a/BesWidgets/BesSlider.h
+++ b/BesWidgets/BesSlider.h
@@ -1,23 +1,32 @@
 ﻿#ifndef BesSlider_H
 #define BesSlider_H
 
+#include <QDebug>
+
 #include <QSlider>
 #include <QMouseEvent>
+
+#include <QStyleOption>
+#include <QProxyStyle>
 
 //实现参考：https://blog.csdn.net/liutingxi0709/article/details/51985618
 class BesSlider :public QSlider
 {
     Q_OBJECT
 public:
-    BesSlider(QWidget* parent = Q_NULLPTR, int handleWidth = 30):QSlider(parent),handleWidthValue(handleWidth){}
+//    BesSlider(QWidget* parent = Q_NULLPTR, int handleWidth = 30):QSlider(parent),handleWidthValue(handleWidth){}
+    BesSlider(QWidget* parent = Q_NULLPTR):QSlider(parent){
+        setStyle(new BesSliderStyle(this->style()));
+        setMouseTracking(true);// 为了鼠标在 sliderSong 上方（不单击）移动时触发 mouseMoveEvent 以显示正确的鼠标形状
+    }
 
     //覆盖 QAbstractSlider::setRange,为了记录范围，判断单前点击的是不是在handle上
-    void setRange(int min, int max)
-    {
-        QAbstractSlider::setRange(min, max);
-        minValue = min;
-        maxValue = max;
-    }
+//    void setRange(int min, int max)
+//    {
+//        QAbstractSlider::setRange(min, max);
+//        minValue = min;
+//        maxValue = max;
+//    }
 
     //是否启用鼠标事件响应
     void enableMouseEvent(bool enable)
@@ -26,54 +35,114 @@ public:
     }
 
 protected:
+    bool isPointInHandle(QPoint point){
+        // https://stackoverflow.com/questions/52550633/how-to-emit-a-signal-if-double-clicking-on-slider-handle
+
+        initStyleOption(&qStyleOptionStyle);
+        QRect subControlRect = this->style()->subControlRect(QStyle::CC_Slider, &qStyleOptionStyle, QStyle::SC_SliderHandle, this);
+        QPoint clickPoint = point;
+
+        return subControlRect.contains(clickPoint);
+    }
+
+    // 用 mouseMoveEvent 事件来处理鼠标形状
+    void mouseMoveEvent(QMouseEvent *ev){
+//        qDebug()<<"mouseMoveEvent: "<<ev->pos();
+
+        if(!enableMouseEvt){
+            QSlider::mouseMoveEvent(ev);
+            return;
+        }
+
+        if (isPointInHandle(ev->pos())) {
+            qDebug() << "handle hovering";
+
+            setCursor(QCursor(Qt::PointingHandCursor));
+        }
+        else{
+            unsetCursor();
+        }
+
+        QSlider::mouseMoveEvent(ev);
+    }
+
     //重写QSlider的mousePressEvent事件
     void mousePressEvent(QMouseEvent *ev)
     {
+        qDebug()<<"void mousePressEvent(QMouseEvent *ev), enableMouseEvt="<<enableMouseEvt;
+
         if(!enableMouseEvt)
             return;
 
+        if (isPointInHandle(ev->pos())) {
+            qDebug() << "handle clicked";
+            QSlider::mousePressEvent(ev);
+        }
+        else{
+            QSlider::mousePressEvent(ev);
+            //发送自定义的鼠标单击信号
+            emit sig_clickNotOnHandle(value());
+        }
+
         //注意应先调用父类的鼠标点击处理事件，这样可以不影响拖动的情况
-        QSlider::mousePressEvent(ev);
+//        QSlider::mousePressEvent(ev); //这会造成移动，之后拿到的value()都是移动后的
 
         //获取鼠标的位置，这里并不能直接从ev中取值（因为如果是拖动的话，鼠标开始点击的位置没有意义了）
-        double posPercent = ev->pos().x() / (double)width();
+//        double posPercent = ev->pos().x() / (double)width();
 
-        int pos = minValue + (int)((maxValue-minValue)* posPercent);
-        int curValue = value();
-        if(pos  < curValue - handleWidthValue/2 || pos  > curValue + handleWidthValue/2)
-        {
+//        int pos = minValue + (int)((maxValue-minValue)* posPercent);
+//        int curValue = value();
+//        if(pos  < curValue - handleWidthValue/2 || pos  > curValue + handleWidthValue/2)
+//        {
             //发送自定义的鼠标单击信号
-            emit sig_clickNotOnHandle(pos);
-        }
+//            emit sig_clickNotOnHandle(pos);
+//        }
     }
 
-    virtual void enterEvent(QEvent *event)
-    {
-        if(enableMouseEvt)
-        {
-            setCursor(QCursor(Qt::PointingHandCursor));
-            QSlider::enterEvent(event);
-        }
-        else
-            setCursor(QCursor(Qt::ArrowCursor));
-    }
+//    virtual void enterEvent(QEvent *event)
+//    {
+//        if(enableMouseEvt)
+//        {
+//            setCursor(QCursor(Qt::PointingHandCursor));
+//            QSlider::enterEvent(event);
+//        }
+//        else
+//            setCursor(QCursor(Qt::ArrowCursor));
+//    }
 
-    virtual void leaveEvent(QEvent *event)
-    {
-        unsetCursor();
+//    virtual void leaveEvent(QEvent *event)
+//    {
+//        unsetCursor();
 
-        if(enableMouseEvt)
-            QSlider::leaveEvent(event);
-    }
+//        if(enableMouseEvt)
+//            QSlider::leaveEvent(event);
+//    }
 
 signals:
     void sig_clickNotOnHandle(int pos);
 
 private:
-    int minValue = 0;
-    int maxValue = 0;
-    double handleWidthValue = 30; //滑块handle的大小，这个取值会作为 sig_clickNotOnHandle 发送时判断是否在handle之外的依据
+//    int minValue = 0;
+//    int maxValue = 0;
+//    double handleWidthValue = 30; //滑块handle的大小，这个取值会作为 sig_clickNotOnHandle 发送时判断是否在handle之外的依据
     bool enableMouseEvt = false;  //默认禁用
+
+    QStyleOptionSlider qStyleOptionStyle;
+
+
+    class BesSliderStyle : public QProxyStyle{
+        // https://stackoverflow.com/questions/12409559/qslider-makes-unnecessary-steps
+        // https://stackoverflow.com/questions/11132597/qslider-mouse-direct-jump
+
+        using QProxyStyle::QProxyStyle;
+
+        int styleHint(QStyle::StyleHint hint,const QStyleOption* option = nullptr, const QWidget* widget = nullptr, QStyleHintReturn* returnData = nullptr) const{
+            if (hint == QStyle::SH_Slider_AbsoluteSetButtons){
+                return (Qt::LeftButton | Qt::MiddleButton | Qt::RightButton);
+            }
+            return QProxyStyle::styleHint(hint, option, widget, returnData);
+        }
+    };
 };
 
 #endif // BesSlider_H

--- a/BesWidgets/BesSlider.h
+++ b/BesWidgets/BesSlider.h
@@ -49,21 +49,17 @@ protected:
     void mouseMoveEvent(QMouseEvent *ev){
 //        qDebug()<<"mouseMoveEvent: "<<ev->pos();
 
-        if(!enableMouseEvt){
-            QSlider::mouseMoveEvent(ev);
-            return;
-        }
+        // 为了精简逻辑，这里无条件调用父类方法，不知有何隐患
+        QSlider::mouseMoveEvent(ev);
 
-        if (isPointInHandle(ev->pos())) {
+        if (enableMouseEvt && isPointInHandle(ev->pos())) {
             qDebug() << "handle hovering";
 
             setCursor(QCursor(Qt::PointingHandCursor));
         }
         else{
-            unsetCursor();
+            unsetCursor();// 去掉 enableMouseEvt 条件判断后，能让鼠标在歌曲结束前变为 Qt::PointingHandCursor 后，在歌曲结束后变回默认样式
         }
-
-        QSlider::mouseMoveEvent(ev);
     }
 
     //重写QSlider的mousePressEvent事件
@@ -74,12 +70,13 @@ protected:
         if(!enableMouseEvt)
             return;
 
-        if (isPointInHandle(ev->pos())) {
+        bool isOnHandle = isPointInHandle(ev->pos());
+        QSlider::mousePressEvent(ev); //在这之后拿到的 pos() 和 value() 都是移动后的，手柄也移动到了新位置，所以需要先判断，存到 isOnHandle 里
+
+        if (isOnHandle) {
             qDebug() << "handle clicked";
-            QSlider::mousePressEvent(ev);
         }
         else{
-            QSlider::mousePressEvent(ev);
             //发送自定义的鼠标单击信号
             emit sig_clickNotOnHandle(value());
         }

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -115,9 +115,9 @@ void BottomWidget::initEntity()
     posAdjust = 0;
 
     musicPlayer = new MusicPlayer(this);
-    musicPlayer->setNotifyInterval(33);
+    musicPlayer->setNotifyInterval(0);//之前是 33。置于 0 能看到 BottomWidget::positionChanged(int position) 被调用的“不同步”导致sliderSong的闪动
 
-    bInMakingMode = false;
+//    bInMakingMode = false;
 }
 
 void BottomWidget::initConnection()
@@ -239,14 +239,14 @@ void BottomWidget::seekBackward(quint64 step)
 //进入制作模式
 void BottomWidget::enterMakingMode()
 {
-    bInMakingMode = true;
+//    bInMakingMode = true;
 }
 
 //middleWidget->pageMain->subPageMaking,SIGNAL(onExitMakingMode()) emitted
 //退出制作模式
 void BottomWidget::exitMakingMode()
 {
-    bInMakingMode = false;
+//    bInMakingMode = false;
 }
 
 //btnPlayAndPause->clicked(bool) emitted
@@ -275,8 +275,8 @@ void BottomWidget::positionChanged(int position)
 {
     if(!AdjustingPos)
     {
-        audioOriginalPos = position; //持续更新 audioOriginalPos，这样在拖动时则会保留拖动时刻的位置
-        qDebug()<<"BottomWidget::positionChanged => audioOriginalPos="<<audioOriginalPos<<" sliderSong->value()="<<sliderSong->value();
+//        audioOriginalPos = position; //持续更新 audioOriginalPos，这样在拖动时则会保留拖动时刻的位置
+        qDebug()<<"void BottomWidget::positionChanged => position="<<position<<" sliderSong->value()="<<sliderSong->value();
 
         int pecentOfThousand = int(1.0 * position / musicPlayer->duration() * 1000);
 
@@ -312,46 +312,54 @@ void BottomWidget::onSliderSongMoved(int position)
 {
     qDebug()<<"void BottomWidget::onSliderSongMoved(int position="<<position<<")";
 
-    if(AdjustingPos){
-        posAdjust = musicPlayer->duration() * position / 1000;
-        showPosition(posAdjust);
-    }
-    else{
+//    if(AdjustingPos){
+        posAdjust = musicPlayer->duration() * static_cast<quint64>(position) / 1000;
+        showPosition(static_cast<int>(posAdjust));
+//    }
+//    else{
         //制作歌词时，AdjustingPos始终为 false, positionChanged 会一直更新进度条，
         //此时，用户按下拖动，也无需处理了
-    }
+//    }
 }
 
 void BottomWidget::onSliderSongPressed()
 {
     qDebug()<<"void BottomWidget::onSliderSongPressed() sliderSong->value()="<<sliderSong->value()<<" musicPlayer->state()="<<musicPlayer->state();
 
-    if(bInMakingMode || musicPlayer->state() == MusicPlayer::StoppedState){
-        return ; //制作模式或停止状态时不允许sliderSong被成功拖动，但并没有阻止信号被接收
-    }
+//    if(bInMakingMode || musicPlayer->state() == MusicPlayer::StoppedState){
+//        return ; //制作模式或停止状态时不允许sliderSong被成功拖动，但并没有阻止信号被接收
+//    }
 
     AdjustingPos = true;
-    posAdjust = -1; // -1 标记表示还没有任何拖动
+//    posAdjust = -1; // -1 标记表示还没有任何拖动
 }
 
 void BottomWidget::onSliderSongReleased()
 {
     qDebug()<<"void BottomWidget::onSliderSongReleased() sliderSong->value()="<<sliderSong->value()<<" posAdjust="<<posAdjust;
 
-    if(AdjustingPos){
-        if(posAdjust == -1)
-            musicPlayer->seek(audioOriginalPos);
-        else
+//    if(AdjustingPos){
+//        if(posAdjust == -1)
+//            musicPlayer->seek(audioOriginalPos);
+//        else
             musicPlayer->seek(posAdjust);
 
         AdjustingPos = false;
-    }
+//    }
 }
 
 void BottomWidget::onSliderSongClickNotOnHandle(int position)
 {
-    int posMusic = musicPlayer->duration() * position / 1000;
-    musicPlayer->seek(posMusic);
+    qDebug()<<"void BottomWidget::onSliderSongClickNotOnHandle(int position"<<position<<")";
+
+//    if(bInMakingMode || musicPlayer->state() == MusicPlayer::StoppedState){
+//        return; //制作模式或停止状态时不允许sliderSong被成功拖动，但并没有阻止信号被接收
+//    }
+
+    posAdjust = musicPlayer->duration() * static_cast<quint64>(position) / 1000;
+
+    //    int posMusic = musicPlayer->duration() * position / 1000;
+    //    musicPlayer->seek(posMusic);
 }
 
 void BottomWidget::onSoundToggle(bool mute)

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -273,6 +273,7 @@ void BottomWidget::durationChanged(qint64 duration)
 //void MainWidget::musicPositionChanged(int pos) invoked
 void BottomWidget::positionChanged(int position)
 {
+    // 拖动 sliderSong 时不处理新位置
     if(!AdjustingPos)
     {
 //        audioOriginalPos = position; //持续更新 audioOriginalPos，这样在拖动时则会保留拖动时刻的位置
@@ -344,7 +345,7 @@ void BottomWidget::onSliderSongReleased()
 //        else
             musicPlayer->seek(posAdjust);
 
-        AdjustingPos = false;
+//        AdjustingPos = false;
 //    }
 }
 
@@ -443,6 +444,16 @@ void BottomWidget::onAudioFinished(bool isEndWithForce)
 void BottomWidget::onAudioPlay()
 {
     qDebug()<<"void BottomWidget::onAudioPlay()";
+
+    // 由于 BottomWidget::positionChanged(int) 有机会在 BottomWidget::onSliderSoundReleased() 之后被调用，
+    //   此时 positionChanged(int) 拿到的是 seek 前的位置，所以 sliderSong 会跳回原位置再到新位置。
+    // 目前，由于 seek 后始终会重新播放，所以 BottomWidget::onAudioPlay() 之后 positionChanged(int) 就能拿到最新位置，
+    //   于是就在这里改变 AdjustingPos 开关，而不是在 onSliderSoundReleased() 中。
+    //
+    // “能用就行。” :)
+    if(AdjustingPos){
+        AdjustingPos = false;
+    }
 
     setStyleSheet("QPushButton#btnPlayAndPause{border-image:url(\":/resource/image/btn_pause.png\");}");
 }

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -127,7 +127,7 @@ void BottomWidget::initConnection()
     connect(sliderSong, &QSlider::sliderPressed, this, &BottomWidget::onSliderSongPressed);
     connect(sliderSong, &QSlider::sliderMoved, this, &BottomWidget::onSliderSongMoved);
     connect(sliderSong, &QSlider::sliderReleased, this, &BottomWidget::onSliderSongReleased);
-    connect(sliderSong, &BesSlider::sig_clickNotOnHandle, this, &BottomWidget::onSliderSongClickNotOnHandle);
+    connect(sliderSong, &BesSlider::sig_refreshClickPos, this, &BottomWidget::onSliderSongClicked);
 
     connect(btnSound, &BesButton::toggled, this, &BottomWidget::onSoundToggle);
     connect(sliderSound, &QSlider::valueChanged, musicPlayer, &MusicPlayer::setVolume);
@@ -276,7 +276,7 @@ void BottomWidget::positionChanged(int position)
     if(!AdjustingPos)
     {
 //        audioOriginalPos = position; //持续更新 audioOriginalPos，这样在拖动时则会保留拖动时刻的位置
-        qDebug()<<"void BottomWidget::positionChanged => position="<<position<<" sliderSong->value()="<<sliderSong->value();
+        qDebug()<<"void BottomWidget::positionChanged => position="<<position<<" sliderSong->value()="<<sliderSong->value()<<" posAdjust="<<posAdjust;
 
         int pecentOfThousand = int(1.0 * position / musicPlayer->duration() * 1000);
 
@@ -348,7 +348,7 @@ void BottomWidget::onSliderSongReleased()
 //    }
 }
 
-void BottomWidget::onSliderSongClickNotOnHandle(int position)
+void BottomWidget::onSliderSongClicked(int position)
 {
     qDebug()<<"void BottomWidget::onSliderSongClickNotOnHandle(int position"<<position<<")";
 

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -276,7 +276,6 @@ void BottomWidget::positionChanged(int position)
     // 拖动 sliderSong 时不处理新位置
     if(!AdjustingPos)
     {
-//        audioOriginalPos = position; //持续更新 audioOriginalPos，这样在拖动时则会保留拖动时刻的位置
         qDebug()<<"void BottomWidget::positionChanged => position="<<position<<" sliderSong->value()="<<sliderSong->value()<<" posAdjust="<<posAdjust;
 
         int pecentOfThousand = int(1.0 * position / musicPlayer->duration() * 1000);
@@ -313,54 +312,29 @@ void BottomWidget::onSliderSongMoved(int position)
 {
     qDebug()<<"void BottomWidget::onSliderSongMoved(int position="<<position<<")";
 
-//    if(AdjustingPos){
-        posAdjust = musicPlayer->duration() * static_cast<quint64>(position) / 1000;
-        showPosition(static_cast<int>(posAdjust));
-//    }
-//    else{
-        //制作歌词时，AdjustingPos始终为 false, positionChanged 会一直更新进度条，
-        //此时，用户按下拖动，也无需处理了
-//    }
+    posAdjust = musicPlayer->duration() * static_cast<quint64>(position) / 1000;
+    showPosition(static_cast<int>(posAdjust));
 }
 
 void BottomWidget::onSliderSongPressed()
 {
     qDebug()<<"void BottomWidget::onSliderSongPressed() sliderSong->value()="<<sliderSong->value()<<" musicPlayer->state()="<<musicPlayer->state();
 
-//    if(bInMakingMode || musicPlayer->state() == MusicPlayer::StoppedState){
-//        return ; //制作模式或停止状态时不允许sliderSong被成功拖动，但并没有阻止信号被接收
-//    }
-
     AdjustingPos = true;
-//    posAdjust = -1; // -1 标记表示还没有任何拖动
 }
 
 void BottomWidget::onSliderSongReleased()
 {
     qDebug()<<"void BottomWidget::onSliderSongReleased() sliderSong->value()="<<sliderSong->value()<<" posAdjust="<<posAdjust;
 
-//    if(AdjustingPos){
-//        if(posAdjust == -1)
-//            musicPlayer->seek(audioOriginalPos);
-//        else
-            musicPlayer->seek(posAdjust);
-
-//        AdjustingPos = false;
-//    }
+    musicPlayer->seek(posAdjust);
 }
 
 void BottomWidget::onSliderSongClicked(int position)
 {
     qDebug()<<"void BottomWidget::onSliderSongClickNotOnHandle(int position"<<position<<")";
 
-//    if(bInMakingMode || musicPlayer->state() == MusicPlayer::StoppedState){
-//        return; //制作模式或停止状态时不允许sliderSong被成功拖动，但并没有阻止信号被接收
-//    }
-
     posAdjust = musicPlayer->duration() * static_cast<quint64>(position) / 1000;
-
-    //    int posMusic = musicPlayer->duration() * position / 1000;
-    //    musicPlayer->seek(posMusic);
 }
 
 void BottomWidget::onSoundToggle(bool mute)

--- a/BottomWidgets/BottomWidget.h
+++ b/BottomWidgets/BottomWidget.h
@@ -48,7 +48,7 @@ private slots:
     void onSliderSongMoved(int position);
     void onSliderSongPressed();
     void onSliderSongReleased();
-    void onSliderSongClickNotOnHandle(int position);
+    void onSliderSongClicked(int position);
 
     void onSoundToggle(bool);
     void onSliderSoundChanged(int);


### PR DESCRIPTION
## 要实现的

#### 鼠标形状

- [x] 鼠标是否在手柄上由控件实际大小计算，而不需要获取 sliderSong 当前进度。
- [x] 鼠标在 sliderSong 中，如果在手柄上，将显示`Qt::PointingHandCursor`，否则不改变形状。这与 网易云音乐 的模式相同；
- [x] 鼠标在 sliderSong 中的形状在`mouseMoveEvent(QMouseEvent *)`方法中处理，而不是`enterEvent(QEvent *event)`或`leaveEvent(QEvent *event)`；

#### 单击 sliderSong 后的行为

- [x] 鼠标在 silderSong 的非手柄位置单击，将会直接跳转，而不是移动一“步”的距离；
- [x] 鼠标单击且不移动手柄，会在手柄所在位置暂停并继续播放。这与 网易云音乐 的模式相同；
- [x] 干掉了`BottomWidget`中很多关于 sliderSong 的冗余的逻辑。
- [ ] 由于`void BottomWidget::positionChanged(int position)`的调用时机问题，在`m_positionUpdateTimer`周期极短时（现在为 0 ，能看得很清楚），sliderSong 在定位到新位置后会闪回原位置，具体的可以看打印的日志。这与`PlayThread`和`MusicPlayer`有一定关系，我还未解决这个问题（在 Windows 10 上现象出现频率降低）。

## 还没做而且意义不大的

- 在不能操作 sliderSong 时鼠标在手柄上方时，手柄样式不改变（即按需改变 sliderSong 的 `QSlider#sliderSound::handle:horizontal:hover`）。

## 放弃的

- 鼠标在 sliderSong 的手柄上方时，手柄周围显示白色辉光。
这在 CSS 中直接用`box-shadow`就行，但是 QSS 不可以。如果是整个控件加阴影，可以用[`QGraphicsDropShadowEffect`](https://doc.qt.io/qt-5/qgraphicsdropshadoweffect.html)，但我无法单独获得手柄这个控件。
所以你在样式（`ISkin.h`）中写的是，当鼠标 hover 时改变中央红色区域半径，而不是仿照 网易云音乐 的模式，我这才知道原因。
相关资料：
  - [\[Qt 4.8\] How to use QGraphicsDropShadowEffect while defining a QStyle ? | Qt Forum](https://forum.qt.io/topic/34661/qt-4-8-how-to-use-qgraphicsdropshadoweffect-while-defining-a-qstyle)
  - [\[Solved\] Unknown property box-shadow styling with CSS | Qt Forum](https://forum.qt.io/topic/26107/solved-unknown-property-box-shadow-styling-with-css)
  - [\[SOLVED\]box-shadow in stylesheet | Qt Forum](https://forum.qt.io/topic/30856/solved-box-shadow-in-stylesheet)
  - [Qt之使用QGraphicsDropShadowEffect添加窗口边框以及文字阴影效果 - 前行之路还需前行 - CSDN博客](https://blog.csdn.net/GoForwardToStep/article/details/91871439)

## 其他

#### 环境

Windows 10 + MSVC 2015 32-bit + Qt 5.9.8
Windows 7 SP1 无开发环境
Ubuntu 18.04 （ GNOME Shell 3.28.2 ）+ gcc 7.4.0 64-bit + Qt 5.9.8

#### 有关的 issue

#8 #21
