### PR TITLE
修复 Windows 下窗口最大化时的定位、重新定位问题

### DIFF
--- a/BesWidgets/BesFramelessWidget.cpp
+++ b/BesWidgets/BesFramelessWidget.cpp
@@ -3,6 +3,8 @@
 #include "BesFramelessWidget.h"
 #include "BesScaleUtil.h"
 
+#include <QDebug>
+
 BesFramelessWidget::BesFramelessWidget(QWidget *parent)
     : BesShadowWidget(parent)
 {
@@ -68,6 +70,15 @@ void BesFramelessWidget::mousePressEvent(QMouseEvent *event)
 
 void BesFramelessWidget::mouseMoveEvent(QMouseEvent *event)
 {
+//    qDebug()<<"BesFramelessWidget::mouseMoveEvent isMaximized()="<<isMaximized();
+
+    if(isMaximized()){
+        QWidget::mouseMoveEvent(event);
+
+        //最大化时不进行更多处理
+        return;
+    }
+
     QPoint gloPoint = event->globalPos();
     QRect rect = this->rect();
     QPoint tl = mapToGlobal(rect.topLeft());

--- a/StackFrame.h
+++ b/StackFrame.h
@@ -38,6 +38,8 @@ protected:
     void mouseMoveEvent(QMouseEvent *event);
     void mousePressEvent(QMouseEvent *event);
 
+    void moveEvent(QMoveEvent *event);
+
     virtual void resizeEvent(QResizeEvent *event);
 
 public slots:
@@ -46,6 +48,10 @@ public slots:
     void SetSpecialSkin(QString skinName, bool bFirstInit = false);  //有一些样式无法实现的效果，放在这里应用
 
     void toggleMaxRestoreStatus();          //切换最大化和恢复2个状态
+    void resizeScreenAvailableRegion(const QRect &geometry); //availableGeometry 变化时，例如任务栏变位置，分辨率变化
+                                                             //  此方法经修改后可以写到 BesFramelessWidget 类中作为公共行为。
+                                                             //  当然，切换最大化与正常状态的代码也需要修改
+
     void toggleSkinBox();                   //显示或隐藏皮肤盒
     void toggleAddItemWidget();             //显示或隐藏添加列表项控件
 


### PR DESCRIPTION
在 Windows 7 / 10 上测试通过：

- 窗口最大化时不再去找 (0, 0) 而是获取实际可用范围，以免被在侧边和上边的任务栏挡住；
- 分辨率变化时收到相应事件以获取实际可用范围；
- 最大化时，跳过`BesFramelessWidget::mouseMoveEvent`中的各种处理，避免最大化状态丢失，同时也让鼠标的样式保持不变，这与普通窗口最大化时的模式一致。
