### PR TITLE
qmake 配置修改以分离输出文件以及自动分发第三方库

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -102,5 +102,24 @@ win32 {
     message($$CONFIG)
     CONFIG -= debug_and_release debug_and_release_target
 
+
+# WIN32_LIB_PATH 位于 musicPlayer.pri 中，以后可以放在独立的 .pri 文件中
+
+# OpenSSL library
+## openssl 1.0.x (binary only)
+
+    OPENSSL_BIN     =   $$WIN32_LIB_PATH/OpenSSL/i386/1.0.2t
+
+    libs_openssl_related.files = $$OPENSSL_BIN/libeay32.dll \
+                   $$OPENSSL_BIN/ssleay32.dll
+
+    #.pro 对 CONFIG 做了调整，不再有 debug 和 release 目录分别在 debug 和 release configuration 下生成
+    CONFIG(debug, debug|release):libs_openssl_related.path = $$OUT_PWD/debug_output
+    CONFIG(release, debug|release):libs_openssl_related.path = $$OUT_PWD/release_output
+
+    INSTALLS += libs_openssl_related
+
+#--
+message(INSTALLS: $$INSTALLS)
 }
 

--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -119,6 +119,59 @@ win32 {
 
     INSTALLS += libs_openssl_related
 
+# Universal C RunTime library
+## ucrt 10.0.14393.795
+
+    UCRT_BIN     =   $$WIN32_LIB_PATH/UCRT/x86/10.0.14393.795
+
+    libs_ucrt_related.files = $$UCRT_BIN/api-ms-win-core-console-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-datetime-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-debug-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-errorhandling-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-file-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-file-l1-2-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-file-l2-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-handle-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-heap-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-interlocked-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-libraryloader-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-localization-l1-2-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-memory-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-namedpipe-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-processenvironment-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-processthreads-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-processthreads-l1-1-1.dll \
+                   $$UCRT_BIN/api-ms-win-core-profile-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-rtlsupport-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-string-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-synch-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-synch-l1-2-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-sysinfo-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-timezone-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-core-util-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-conio-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-convert-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-environment-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-filesystem-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-heap-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-locale-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-math-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-multibyte-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-private-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-process-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-runtime-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-stdio-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-string-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-time-l1-1-0.dll \
+                   $$UCRT_BIN/api-ms-win-crt-utility-l1-1-0.dll \
+                   $$UCRT_BIN/ucrtbase.dll
+
+    #.pro 对 CONFIG 做了调整，不再有 debug 和 release 目录分别在 debug 和 release configuration 下生成
+    CONFIG(debug, debug|release):libs_ucrt_related.path = $$OUT_PWD/debug_output
+    CONFIG(release, debug|release):libs_ucrt_related.path = $$OUT_PWD/release_output
+
+    INSTALLS += libs_ucrt_related
+
 #--
 message(INSTALLS: $$INSTALLS)
 }

--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -74,3 +74,32 @@ RC_FILE = Beslyric.rc
 macx{
 ICON = Beslyric.icns
 }
+
+# https://stackoverflow.com/questions/3440387/how-to-put-generated-files-e-g-object-files-into-a-separate-folder-when-using
+# 中间文件都放在 <conf>_generated 下，生成的二进制文件放在 <conf>_output 下
+
+CONFIG(debug, debug|release) {
+    OBJECTS_DIR = $$OUT_PWD/debug_generated
+    MOC_DIR = $$OUT_PWD/debug_generated
+    RCC_DIR = $$OUT_PWD/debug_generated
+
+    DESTDIR = $$OUT_PWD/debug_output
+}
+CONFIG(release, debug|release) {
+    OBJECTS_DIR = $$OUT_PWD/release_generated
+    MOC_DIR = $$OUT_PWD/release_generated
+    RCC_DIR = $$OUT_PWD/release_generated
+
+    DESTDIR = $$OUT_PWD/release_output
+}
+
+win32 {
+
+# https://stackoverflow.com/questions/28993418/qt-creator-creates-both-a-debug-and-a-release-folder-inside-the-designated-debug
+# https://stackoverflow.com/questions/1298988/qt-does-not-create-output-files-in-debug-release-folders-in-linux
+
+    message($$CONFIG)
+    CONFIG -= debug_and_release debug_and_release_target
+
+}
+

--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -77,6 +77,7 @@ ICON = Beslyric.icns
 
 # https://stackoverflow.com/questions/3440387/how-to-put-generated-files-e-g-object-files-into-a-separate-folder-when-using
 # 中间文件都放在 <conf>_generated 下，生成的二进制文件放在 <conf>_output 下
+# 注意 musicPlayer.pri 中关于 INSTALLS 的配置也与这个有关
 
 CONFIG(debug, debug|release) {
     OBJECTS_DIR = $$OUT_PWD/debug_generated

--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -172,6 +172,21 @@ win32 {
 
     INSTALLS += libs_ucrt_related
 
+# Microsoft C RunTime library
+## crt 14.0.24234.1
+
+    CRT_BIN     =   $$WIN32_LIB_PATH/CRT/x86/14.0.24234.1
+
+    libs_crt_related.files = $$CRT_BIN/concrt140.dll \
+                   $$CRT_BIN/msvcp140.dll \
+                   $$CRT_BIN/vcruntime140.dll
+
+    #.pro 对 CONFIG 做了调整，不再有 debug 和 release 目录分别在 debug 和 release configuration 下生成
+    CONFIG(debug, debug|release):libs_crt_related.path = $$OUT_PWD/debug_output
+    CONFIG(release, debug|release):libs_crt_related.path = $$OUT_PWD/release_output
+
+    INSTALLS += libs_crt_related
+
 #--
 message(INSTALLS: $$INSTALLS)
 }

--- a/Entities/MusicPlayer/musicPlayer.pri
+++ b/Entities/MusicPlayer/musicPlayer.pri
@@ -17,15 +17,19 @@ win32{
 #根据开发者自己 ffmpeg 和 sdl 库路径，可对如下路径进行修改，不过建议 库安装在 C:/lib 下，
 #   具体使用步骤，可参看项目： https://github.com/BensonLaur/beslyric-lib
 
+WIN32_LIB_PATH = C:/lib/beslyric-lib
+
 #ffmpeg
 
-FFMPEG_INCLUDE  =   C:/lib/beslyric-lib/win32/ffmpeg_4_0_1/include
-FFMPEG_LIB      =   C:/lib/beslyric-lib/win32/ffmpeg_4_0_1/lib
+FFMPEG_INCLUDE  =   $$WIN32_LIB_PATH/win32/ffmpeg_4_0_1/include
+FFMPEG_LIB      =   $$WIN32_LIB_PATH/win32/ffmpeg_4_0_1/lib
+FFMPEG_BIN      =   $$WIN32_LIB_PATH/win32/ffmpeg_4_0_1/bin
 
 #sdl
 
-SDL_INCLUDE     =   C:/lib/beslyric-lib/SDL_2_0_3/include
-SDL_LIB         =   C:/lib/beslyric-lib/SDL_2_0_3/lib
+SDL_INCLUDE     =   $$WIN32_LIB_PATH/SDL_2_0_3/include
+SDL_LIB         =   $$WIN32_LIB_PATH/SDL_2_0_3/lib
+SDL_BIN         =   $$WIN32_LIB_PATH/SDL_2_0_3/bin
 
 #other
 #OTHER_INCLUDE   =   C:/lib/beslyric-lib/win32/include
@@ -45,6 +49,28 @@ LIBS += -L$$FFMPEG_LIB/ -lavcodec\
         -L$$FFMPEG_LIB/ -lswresample \
         -L$$SDL_LIB/ -lSDL2main  \
         -L$$SDL_LIB/ -lSDL2
+
+# https://stackoverflow.com/questions/6771039/automatic-copy-of-dependent-files-in-qt-creator
+# https://doc.qt.io/qt-5/qmake-advanced-usage.html#installing-files
+
+libs_ffmpeg_related.files = $$FFMPEG_BIN/avcodec-58.dll \
+                   $$FFMPEG_BIN/avdevice-58.dll \
+                   $$FFMPEG_BIN/avfilter-7.dll \
+                   $$FFMPEG_BIN/avformat-58.dll \
+                   $$FFMPEG_BIN/avutil-56.dll \
+                   $$FFMPEG_BIN/postproc-55.dll \
+                   $$FFMPEG_BIN/swresample-3.dll \
+                   $$FFMPEG_BIN/swscale-5.dll \
+                   $$SDL_BIN/SDL2.dll
+
+#.pro 对 CONFIG 做了调整，不再有 debug 和 release 目录分别在 debug 和 release configuration 下生成
+CONFIG(debug, debug|release):libs_ffmpeg_related.path = $$OUT_PWD/debug_output
+CONFIG(release, debug|release):libs_ffmpeg_related.path = $$OUT_PWD/release_output
+
+#    message(Beslyric-for-X.pro libs_ffmpeg_related.files: $$libs_ffmpeg_related.files)
+#    message(Beslyric-for-X.pro libs_ffmpeg_related.path: $$libs_ffmpeg_related.path)
+
+INSTALLS += libs_ffmpeg_related
 }
 
 


### PR DESCRIPTION
```
<conf> ::= debug | release
```

- [x] 1. 取消 Windows 平台的 Qt 默认设置的 qmake 参数`debug_and_release`和`debug_and_release_target`，使目录结构由：
  ```
  root
  |- build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Debug
  |  |- Debug
  |  |  |- .moc
  |  |  |- .obj
  |  |  |- .rc
  |  |   \ Beslyric-for-X.exe
  |  |- Release
  |  |   \ <empty>
  |  |- Makefile
  |  |- Makefile.Debug
  |   \ Makefile.Release
   \ build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Release
     |- Debug
     |   \ <empty>
     |- Release
     |  |- .moc
     |  |- .obj
     |  |- .rc
     |   \ Beslyric-for-X.exe
     |- Makefile
     |- Makefile.Debug
      \ Makefile.Release
  ```
  变为：
  ```
  root
  |- build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Debug
  |  |- .moc
  |  |- .obj
  |  |- .rc
  |  |- Beslyric-for-X.exe
  |   \ Makefile
   \ build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Release
     |- .moc
     |- .obj
     |- .rc
     |- Beslyric-for-X.exe
      \ Makefile
  ```
  - [c++ - Qt Creator creates both a debug and a release folder inside the designated debug folder - Stack Overflow](https://stackoverflow.com/questions/28993418/qt-creator-creates-both-a-debug-and-a-release-folder-inside-the-designated-debug)
  - [Qt does not create output files in debug/release folders in Linux - Stack Overflow](https://stackoverflow.com/questions/1298988/qt-does-not-create-output-files-in-debug-release-folders-in-linux)
- [x] 2. （这是解决第 1 点导致的文件太乱的问题，当然原本也乱）二进制文件置于`<conf>_output`文件夹，以便在`qmake install`和`windeployqt`之后厘清需要打包到安装程序中的文件；
  - [How to put generated files (e.g. object files) into a separate folder when using Qt/qmake? - Stack Overflow](https://stackoverflow.com/questions/3440387/how-to-put-generated-files-e-g-object-files-into-a-separate-folder-when-using)
  - [DESTDIR # Variables | qmake Manual](https://doc.qt.io/qt-5/qmake-variable-reference.html#destdir)
- [x] 3. 使用`qmake install`复制 FFmpeg 、 SDL2 、 OpenSSL （与 #29 有关）以及 UCRT 和 CRT 的库文件到`<conf>_output`文件夹。注意 OpenSSL 、 UCRT 和 CRT 的库**现在**（指 PR 提交时，除非 BensonLaur/beslyric-lib#1 、 BensonLaur/beslyric-lib#2 和 BensonLaur/beslyric-lib#3 被合并）是不存在的。
  - [Installing Files # Advanced Usage | qmake Manual](https://doc.qt.io/qt-5/qmake-advanced-usage.html#installing-files)
  - [c++ - Automatic Copy of Dependent Files in Qt Creator - Stack Overflow](https://stackoverflow.com/questions/6771039/automatic-copy-of-dependent-files-in-qt-creator)
  - [c++ - (Qt 5.7.0) Could not find or load the qt platform plugin &quot;windows&quot; - Stack Overflow](https://stackoverflow.com/questions/38359850/qt-5-7-0-could-not-find-or-load-the-qt-platform-plugin-windows)

对于 Windows 平台，若按照本 PR 的内容进行修改，同时在构建后及时使用`windeployqt`部署，`<conf>_output`文件夹中就是开箱即用的 Beslyric-for-X 了。
