### PR TITLE
移除显式指定使用 Qt5Network(d)

### DIFF
--- a/Utility/Utility.pri
+++ b/Utility/Utility.pri
@@ -13,6 +13,6 @@ SOURCES+=\
 
 #mac下只需要 QT += network 即可，linux 和 windows 才需要明确指定 Qt5NetWork
 !macx{
-    CONFIG(debug, debug|release):LIBS += -lQt5Networkd
-    CONFIG(release, debug|release):LIBS += -lQt5Network
+#    CONFIG(debug, debug|release):LIBS += -lQt5Networkd
+#    CONFIG(release, debug|release):LIBS += -lQt5Network
 }


### PR DESCRIPTION
已在 Windows 7 / 10 和 Ubuntu 18.04 上的 Qt 5.9.8 测试。

Windows 上去掉`Qt5Network(d)` 功能正常；
Ubuntu 上**不去掉**`Qt5Network(d)`会报找不到库的错：
```
/usr/bin/ld: cannot find -lQt5Networkd
```

等待你进一步的验证。