### PR TITLE
似乎解决了"no data in list for 1e8 times access"这个问题

### DIFF
--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -173,29 +173,7 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
 			//使用 av_rescale_q 转换得到 微秒时间
 			AVRational aVRational = { 1, AV_TIME_BASE };
 			int64_t res = av_rescale_q(packet.pts, pFormatCtx->streams[audioStream]->time_base, aVRational);
-
-
-//			static int64_t lastRes = 0;		//用于记录最后一次的时间
-//			static int64_t tryTimes = 0;
-
-//			if (lastRes != res)				//与上次时间不同时，发送位置改变信号
-//			{
-				MS->audio_clock = res * 1.0 / 1000;
-//				lastRes = res;
-//				tryTimes = 0;
-//			}
-//			else
-//			{
-//                tryTimes++;
-//                //wanted_spec.callback = fillAudio 会在PacketQueue 队列中认为寻找数据，认为1亿次获取如果没有结果则意味着音乐结束
-//                if (tryTimes >= 100000000LL)
-//				{
-//					qDebug() << "no data in list for 1e8 times access";
-//					AGStatus = AGS_FINISH;
-//				}
-
-//				return -1; // It works... Why?
-//			}
+			MS->audio_clock = res * 1.0 / 1000;
 
 			//方式二：
             //MS->audio_clock = (double)av_q2d(MS->aStream->time_base) * (double)packet.pts;
@@ -244,7 +222,6 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
         }
         return -1;
     }
-//    return -1;
 }
 
 

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -175,17 +175,17 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
 			int64_t res = av_rescale_q(packet.pts, pFormatCtx->streams[audioStream]->time_base, aVRational);
 
 
-			static int64_t lastRes = 0;		//用于记录最后一次的时间
+//			static int64_t lastRes = 0;		//用于记录最后一次的时间
 //			static int64_t tryTimes = 0;
 
-			if (lastRes != res)				//与上次时间不同时，发送位置改变信号
-			{
+//			if (lastRes != res)				//与上次时间不同时，发送位置改变信号
+//			{
 				MS->audio_clock = res * 1.0 / 1000;
-				lastRes = res;
+//				lastRes = res;
 //				tryTimes = 0;
-			}
-			else
-			{
+//			}
+//			else
+//			{
 //                tryTimes++;
 //                //wanted_spec.callback = fillAudio 会在PacketQueue 队列中认为寻找数据，认为1亿次获取如果没有结果则意味着音乐结束
 //                if (tryTimes >= 100000000LL)
@@ -194,8 +194,8 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
 //					AGStatus = AGS_FINISH;
 //				}
 
-				return -1; // It works... Why?
-			}
+//				return -1; // It works... Why?
+//			}
 
 			//方式二：
             //MS->audio_clock = (double)av_q2d(MS->aStream->time_base) * (double)packet.pts;
@@ -242,8 +242,9 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
             av_free_packet(&packet);
             return MS->wanted_frame->channels * len2 * av_get_bytes_per_sample((AVSampleFormat)MS->wanted_frame->format);
         }
+        return -1;
     }
-    return -1;
+//    return -1;
 }
 
 

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -99,7 +99,7 @@ int packet_queue_get(PacketQueue *q, AVPacket *pkt, int block)
             ret = 1;
             break;
         } else if (!block) {
-            ret = 0;
+            ret = -1;
             break;
         } else
         {

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -176,23 +176,25 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
 
 
 			static int64_t lastRes = 0;		//用于记录最后一次的时间
-			static int64_t tryTimes = 0;
+//			static int64_t tryTimes = 0;
 
 			if (lastRes != res)				//与上次时间不同时，发送位置改变信号
 			{
 				MS->audio_clock = res * 1.0 / 1000;
 				lastRes = res;
-				tryTimes = 0;
+//				tryTimes = 0;
 			}
 			else
 			{
-                tryTimes++;
-                //wanted_spec.callback = fillAudio 会在PacketQueue 队列中认为寻找数据，认为1亿次获取如果没有结果则意味着音乐结束
-                if (tryTimes >= 100000000LL)
-				{
-					qDebug() << "no data in list for 1e8 times access";
-					AGStatus = AGS_FINISH;
-				}
+//                tryTimes++;
+//                //wanted_spec.callback = fillAudio 会在PacketQueue 队列中认为寻找数据，认为1亿次获取如果没有结果则意味着音乐结束
+//                if (tryTimes >= 100000000LL)
+//				{
+//					qDebug() << "no data in list for 1e8 times access";
+//					AGStatus = AGS_FINISH;
+//				}
+
+				return -1; // It works... Why?
 			}
 
 			//方式二：


### PR DESCRIPTION
与 #23 有关。

我并没有研究与 SDL 相关的代码，仅仅是对逻辑进行了一些分析，尝试直接跳过对`tryTimes`和`AGStatus`的处理，返回`-1`。

做测试，快速切换、重新播放歌曲，就暂时没有出现卡死的情况了。

已在 Windows 10 、 Ubuntu 18.04 和 macOS 10.14 下做了测试。

这个 PR 需要继续讨论，其中的道理可能也需要学习 SDL 后才能搞明白吧。

---

上述内容与提交 d05c494 有关（我又一次弄坏了 git 历史）。