### PR TITLE
Remove SDL_INIT_TIMER and SDL_INIT_VIDEO from SDL_Init()

### DIFF
--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -474,7 +474,7 @@ bool PlayThread::initDeviceAndFfmpegContext()
 //SDL------------------
 #if USE_SDL
     //Init
-    if(SDL_Init(SDL_INIT_VIDEO | SDL_INIT_AUDIO | SDL_INIT_TIMER)) {
+    if(SDL_Init(SDL_INIT_AUDIO)) {
         const char* errorString = SDL_GetError();
         printf( "Could not initialize SDL - %s\n", errorString);
         emit errorOccur(6,QString(tr("无法初始化播放设备模块 SDL - %s.")).arg(errorString)); //QString("Could not initialize SDL - %s.").arg(errorString)


### PR DESCRIPTION
相比于之前的写法，现在从点击音乐到音乐开始播放的延迟缩短了许多。

不同平台的表现：
- Ubuntu 18.04 下现象明显；
- Windows 10 1903 下没有明显改变；
- macOS 10.15 下没有明显改变。

注：之后的 PR 中，若无特别说明，所使用的 FFmpeg 版本均与 beslyric-lib 一致（例如现在为 4.0.1 ）。