### PR TITLE
使最大化窗口自适应屏幕可用区域

### DIFF
--- a/StackFrame.cpp
+++ b/StackFrame.cpp
@@ -4,6 +4,8 @@
 #include "SettingManager.h"
 #include "BesScaleUtil.h"
 
+#include <QScreen>
+
 StackFrame::StackFrame(QApplication *pApplication,QWidget *parent)
     : BesFramelessWidget(parent),mainWidget(nullptr),skinBoxWidget(nullptr),addItemWidget(nullptr)
 {
@@ -231,8 +233,18 @@ void  StackFrame::toggleMaxRestoreStatus()
     else
     {
         showMaximized();
+        //在桌面左上角不为 (0, 0) 时，这个就不能用了
+//        setGeometry(-borderMain, -borderMain, width()+2*borderMain, height()+ 2*borderMain);
 
-        setGeometry(-borderMain, -borderMain, width()+2*borderMain, height()+ 2*borderMain);
+        //https://stackoverflow.com/questions/2641193/qt-win-showmaximized-overlapping-taskbar-on-a-frameless-window
+        //要获取真实的可用范围，而不是写死
+
+        //'availableGeometry' is deprecated: Use QGuiApplication::screens()
+//        QRect availableGeometry(QApplication::desktop()->availableGeometry());
+        QRect availableGeometry(QGuiApplication::screens().first()->availableGeometry());
+
+        availableGeometry.adjust(-borderMain, -borderMain, borderMain, borderMain);
+        setGeometry(availableGeometry);
 
         mainWidget->topWidget->btnMax->setVisible(false);
         mainWidget->topWidget->btnRestore->setVisible(true);


### PR DESCRIPTION
在 Windows 10 1903 / macOS 10.15 下测试通过；
而 Ubuntu 18.04 (GNOME Shell 3.28.2) 本身具有这样的特性，本 PR 对其没有影响。

使用`QScreen->availableGeometry()`获得屏幕可用区域再做运算，而不是把 (0, 0) 作为左上角。

暂时没有考虑多屏幕的情况，所以直接使用`QGuiApplication::screens()`列表的第一个`QScreen`的指针。