### PR TITLE
Use calculated buffer size.

### DIFF
--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -487,7 +487,7 @@ bool PlayThread::initDeviceAndFfmpegContext()
     wanted_spec.channels = out_channels;
     wanted_spec.silence = 0;
     wanted_spec.samples = out_nb_samples;
-    wanted_spec.size = 1024;
+    wanted_spec.size = out_buffer_size;
     wanted_spec.callback = fillAudio;
     wanted_spec.userdata =  &m_MS;
 


### PR DESCRIPTION
Minor fix.
Use av_samples_get_buffer_size() to calculate the size of the buffer.