### PR TITLE
新的 BesSlider 和更好用的 MusicPlayer

### DIFF
--- a/BesWidgets/BesSlider.h
+++ b/BesWidgets/BesSlider.h
@@ -1,22 +1,23 @@
 ﻿#ifndef BesSlider_H
 #define BesSlider_H
 
+#include <QDebug>
+
 #include <QSlider>
 #include <QMouseEvent>
 
+#include <QStyleOption>
+#include <QProxyStyle>
+
 //实现参考：https://blog.csdn.net/liutingxi0709/article/details/51985618
+//  注意，现在的实现已经与上述链接中的内容差很远了。
 class BesSlider :public QSlider
 {
     Q_OBJECT
 public:
-    BesSlider(QWidget* parent = Q_NULLPTR, int handleWidth = 30):QSlider(parent),handleWidthValue(handleWidth){}
-
-    //覆盖 QAbstractSlider::setRange,为了记录范围，判断单前点击的是不是在handle上
-    void setRange(int min, int max)
-    {
-        QAbstractSlider::setRange(min, max);
-        minValue = min;
-        maxValue = max;
+    BesSlider(QWidget* parent = Q_NULLPTR):QSlider(parent){
+        setStyle(new BesSliderStyle(this->style()));
+        setMouseTracking(true);// 为了鼠标在 slider 上方（不点击）移动时触发 mouseMoveEvent 以显示正确的鼠标形状
     }
 
     //是否启用鼠标事件响应
@@ -25,55 +26,114 @@ public:
         enableMouseEvt = enable;
     }
 
+private:
+    QRect getHandleRect(){
+        // https://stackoverflow.com/questions/52550633/how-to-emit-a-signal-if-double-clicking-on-slider-handle
+
+        initStyleOption(&qStyleOptionStyle);
+        QRect subControlRect = this->style()->subControlRect(QStyle::CC_Slider, &qStyleOptionStyle, QStyle::SC_SliderHandle, this);
+
+        return subControlRect;
+    }
+
 protected:
-    //重写QSlider的mousePressEvent事件
+    // 用 mouseMoveEvent 事件来处理鼠标形状
+    void mouseMoveEvent(QMouseEvent *ev){
+        qDebug()<<"BesSlider::mouseMoveEvent: "<<ev->pos();
+
+        // 通过偏移计算 handle 的正确位置
+        ev->setLocalPos(ev->pos() += click_pos_offset);
+
+        // 如果需要在 enableMouseEvt == false 时，鼠标移动到 handle 上也改变鼠标样式，就去掉关于 enableMouseEvt 的判断。
+        if (enableMouseEvt && getHandleRect().contains(ev->pos())) {
+            qDebug() << "handle hovering";
+
+            setCursor(QCursor(Qt::PointingHandCursor));
+        }
+        else{
+            unsetCursor();
+        }
+
+        QSlider::mouseMoveEvent(ev);
+    }
+
+    void mouseReleaseEvent(QMouseEvent *ev){
+        qDebug()<<"BesSlider::mouseReleaseEvent ev->pos()"<<ev->pos()<<value();
+
+        if(!enableMouseEvt){
+            return;
+        }
+
+        QSlider::mouseReleaseEvent(ev);
+
+        // 复位偏移，避免对 mouseMoveEvent() 方法中关于鼠标是否在 handle 上的判断造成干扰。
+        click_pos_offset = QPoint(0, 0);
+    }
+
+    //重写QSlider的mousePressEvent事件 &QSlider::sliderPressed 的接收者由 sig_clickNotOnHandle 信号获得最新位置
     void mousePressEvent(QMouseEvent *ev)
     {
-        if(!enableMouseEvt)
+        qDebug()<<"BesSlider::mousePressEvent(QMouseEvent *ev), enableMouseEvt="<<enableMouseEvt;
+
+        if(!enableMouseEvt){
             return;
-
-        //注意应先调用父类的鼠标点击处理事件，这样可以不影响拖动的情况
-        QSlider::mousePressEvent(ev);
-
-        //获取鼠标的位置，这里并不能直接从ev中取值（因为如果是拖动的话，鼠标开始点击的位置没有意义了）
-        double posPercent = ev->pos().x() / (double)width();
-
-        int pos = minValue + (int)((maxValue-minValue)* posPercent);
-        int curValue = value();
-        if(pos  < curValue - handleWidthValue/2 || pos  > curValue + handleWidthValue/2)
-        {
-            //发送自定义的鼠标单击信号
-            emit sig_clickNotOnHandle(pos);
         }
-    }
 
-    virtual void enterEvent(QEvent *event)
-    {
-        if(enableMouseEvt)
-        {
+        qDebug()<<"BesSlider::mousePressEvent() old value:"<<value();
+
+        QRect handle_rect = getHandleRect();
+        if (handle_rect.contains(ev->pos())) {
+            qDebug() << "handle clicked";
+
+            QPoint center_of_handle = handle_rect.center();
+
+            // 计算偏移
+            click_pos_offset = center_of_handle - ev->pos();
+            qDebug()<<"click_pos_offset:"<<click_pos_offset;
+
+            //用 handle 中心点代替实际点击位置，避免在点击到 handle 非中心位置时移动 handle，使 handle 看起来是能在任何位置被拖动的
+            ev->setLocalPos(center_of_handle);
+        }else{
+            qDebug() << "handle not clicked";
+
+            // 当鼠标点击 slider 非 handle 位置后，当 handle 移动到鼠标位置时，样式变为指针。
             setCursor(QCursor(Qt::PointingHandCursor));
-            QSlider::enterEvent(event);
         }
-        else
-            setCursor(QCursor(Qt::ArrowCursor));
-    }
 
-    virtual void leaveEvent(QEvent *event)
-    {
-        unsetCursor();
+        QSlider::mousePressEvent(ev); //在这之后， handle 移动到了点击的位置，value() 也变为点击处的值，所以任何判断都要在之前进行
 
-        if(enableMouseEvt)
-            QSlider::leaveEvent(event);
+        qDebug()<<"BesSlider::mousePressEvent() new value:"<<value();
+
+        // 发出包含点击位置处的取值的信号，接收者用新值刷新相关组件（例如实时显示 QSlider 取值的 QLabel）的值。
+        //   &QSlider::sliderPressed() 信号不包含点击位置，所以需要这个额外的信号。
+        emit sig_clickNotOnHandle(value());
     }
 
 signals:
     void sig_clickNotOnHandle(int pos);
 
 private:
-    int minValue = 0;
-    int maxValue = 0;
-    double handleWidthValue = 30; //滑块handle的大小，这个取值会作为 sig_clickNotOnHandle 发送时判断是否在handle之外的依据
-    bool enableMouseEvt = false;  //默认禁用
+    bool enableMouseEvt = false;  //默认禁用，仅在非制作模式播放时启用
+
+    QStyleOptionSlider qStyleOptionStyle;
+
+    //在 handle 上的点击位置距离 handle 中心点的偏移距离
+    QPoint click_pos_offset = QPoint(0, 0);
+
+
+    class BesSliderStyle : public QProxyStyle{
+        // https://stackoverflow.com/questions/12409559/qslider-makes-unnecessary-steps
+        // https://stackoverflow.com/questions/11132597/qslider-mouse-direct-jump
+
+        using QProxyStyle::QProxyStyle;
+
+        int styleHint(QStyle::StyleHint hint,const QStyleOption* option = nullptr, const QWidget* widget = nullptr, QStyleHintReturn* returnData = nullptr) const{
+            if (hint == QStyle::SH_Slider_AbsoluteSetButtons){
+                return (Qt::LeftButton | Qt::MiddleButton | Qt::RightButton);
+            }
+            return QProxyStyle::styleHint(hint, option, widget, returnData);
+        }
+    };
 };
 
 #endif // BesSlider_H

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -115,7 +115,7 @@ void BottomWidget::initEntity()
     posAdjust = 0;
 
     musicPlayer = new MusicPlayer(this);
-    musicPlayer->setNotifyInterval(33);
+    musicPlayer->setNotifyInterval(0);
 
     bInMakingMode = false;
 }

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -115,7 +115,6 @@ void BottomWidget::initEntity()
     posAdjust = 0;
 
     musicPlayer = new MusicPlayer(this);
-    musicPlayer->setNotifyInterval(0);
 
     bInMakingMode = false;
 }

--- a/BottomWidgets/BottomWidget.cpp
+++ b/BottomWidgets/BottomWidget.cpp
@@ -141,6 +141,9 @@ void BottomWidget::initConnection()
     connect(musicPlayer, &MusicPlayer::seekFinished, this, [&](){
         AdjustingPos = false;
     });
+    connect(musicPlayer, &MusicPlayer::seekError, this, [&](){
+        AdjustingPos = false;
+    });
 
     connect(musicPlayer, &MusicPlayer::durationChanged, this, &BottomWidget::durationChanged);
     connect(musicPlayer, &MusicPlayer::errorOccur, this, &BottomWidget::onErrorOccurs);

--- a/BottomWidgets/BottomWidget.h
+++ b/BottomWidgets/BottomWidget.h
@@ -95,8 +95,6 @@ private:
 
     bool AdjustingPos;
     quint64 posAdjust;
-
-    int audioOriginalPos; //音频被按下时的位置（为了记录下精确地时间，记录音频位置，之前记录slider位置精度不够会导致偏移）
 };
 
 #endif // BOTTOMWIDGET_H

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -521,9 +521,6 @@ void PlayThread::generateAudioDataLoop()
 
     AVPacket packet;
 
-    AVPacket *ppacket = nullptr;  //分配用于转换的数据包(输入)
-    AVFrame	*pFrame = nullptr;    //分配用于转换的数据包(解码输出)
-
     while(!g_isQuit)
     {
         switch (AGStatus) {
@@ -601,11 +598,6 @@ void PlayThread::generateAudioDataLoop()
             break;
         }
     }
-
-    if(ppacket)             //释放 packet 本身
-        av_free(ppacket);
-    if(pFrame)              //释放 frame 本身
-       av_frame_free(&pFrame);
 }
 
 

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -178,6 +178,7 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
             {
                 logAudio = false;
                 qDebug() << "to " <<MS->audio_clock ;
+                emit seekFinished();
             }
 
         if (packet.size > 0)
@@ -739,6 +740,7 @@ MusicPlayer::MusicPlayer(QObject* parent):QObject(parent),m_volume(128)
 
         emit positionChanged(0); // 最后触发一次 BottomWidget::positionChanged，如果是单曲播放，则可达到进度条清零的效果
     });
+    connect(playThread, &PlayThread::seekFinished, [&](){emit seekFinished();});
     connect(playThread, &PlayThread::volumeChanged,[=](uint8_t volume){
         emit volumeChanged(volume);}
     );

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -99,7 +99,7 @@ int packet_queue_get(PacketQueue *q, AVPacket *pkt, int block)
             ret = 1;
             break;
         } else if (!block) {
-            ret = 0;
+            ret = -1;
             break;
         } else
         {
@@ -142,78 +142,51 @@ void destroy_queue_context(PacketQueue* q)
 
 int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
 {
-    static AVFrame *pframe=NULL;        //一帧
-    static SwrContext*pSwr_ctx=NULL;    //转换
+    AVFrame *pframe=NULL;        //一帧
+    SwrContext*pSwr_ctx=NULL;    //转换
     AVPacket packet;                    //包
 
-    int decodeLen=0;
-    int got_frame = 0;
-    int audio_pkt_size=0;
-    uint8_t* audio_pkt_data=NULL;
-
-    if(pframe)
-       av_frame_free(&pframe);
-    pframe=av_frame_alloc();
+    int returns = -1; //除非音频解码成功返回音频数据，否则返回 -1
 
     while (true)
     {
         if (packet_queue_get(&MS->audioq, &packet, 0) < 0)
         {
-            return -1;
+            break;
         }
-        audio_pkt_data =packet.data;
-        audio_pkt_size = packet.size;
-
-        if (packet.pts != AV_NOPTS_VALUE)
+        if (packet.pts == AV_NOPTS_VALUE)
         {
+            break;
+        }
 
 			//方式一:
 			//packet->pts 时间基于  AVStream->time_base units
-			//外部时间基于 1/AV_TIME_BASE 即 1微秒
-			//使用 av_rescale_q 转换得到 微秒时间
-			AVRational aVRational = { 1, AV_TIME_BASE };
-			int64_t res = av_rescale_q(packet.pts, pFormatCtx->streams[audioStream]->time_base, aVRational);
-
-
-			static int64_t lastRes = 0;		//用于记录最后一次的时间
-			static int64_t tryTimes = 0;
-
-			if (lastRes != res)				//与上次时间不同时，发送位置改变信号
-			{
-				MS->audio_clock = res * 1.0 / 1000;
-				lastRes = res;
-				tryTimes = 0;
-			}
-			else
-			{
-                tryTimes++;
-                //wanted_spec.callback = fillAudio 会在PacketQueue 队列中认为寻找数据，认为1亿次获取如果没有结果则意味着音乐结束
-                if (tryTimes >= 100000000LL)
-				{
-					qDebug() << "no data in list for 1e8 times access";
-					AGStatus = AGS_FINISH;
-				}
-			}
+			//外部时间基于 1/1000 即 1毫秒
+			//使用 av_rescale_q 转换得到 毫秒时间
+			AVRational aVRational = { 1, 1000 };
+			qint64 res = av_rescale_q(packet.pts, pFormatCtx->streams[audioStream]->time_base, aVRational);
+			MS->audio_clock = res;
 
 			//方式二：
             //MS->audio_clock = (double)av_q2d(MS->aStream->time_base) * (double)packet.pts;
             //MS->audio_clock *= 1000;
 
+            // AGStatus 由 AGS_SEEK 到 AGS_PLAYING 后， MS->audio_clock 才是拿到 seek 后的时间。
+            //   当然，通常在进入这个判断分支前 AGStatus 已是 AGS_PLAYING ，但仍有极少对立情况出现（出现频率为 2/193）。
+//            if(logAudio && getAGStatus() != AGS_SEEK)
             if(logAudio)
             {
                 logAudio = false;
                 qDebug() << "to " <<MS->audio_clock ;
             }
-        }
 
-        while (audio_pkt_size > 0)
+        if (packet.size > 0)
         {
-            decodeLen = avcodec_decode_audio4(MS->acct, pframe, &got_frame, &packet);
+            pframe=av_frame_alloc();
+            int got_frame;
+            int decodeLen = avcodec_decode_audio4(MS->acct, pframe, &got_frame, &packet);
             if (decodeLen < 0) // 出错，跳过
                 break;
-
-            audio_pkt_data += decodeLen;
-            audio_pkt_size -= decodeLen;
 
             if (pframe->channels > 0 && pframe->channel_layout == 0)
                 pframe->channel_layout = av_get_default_channel_layout(pframe->channels);
@@ -221,8 +194,6 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
                 pframe->channels = av_get_channel_layout_nb_channels(pframe->channel_layout);
 
 
-            if (pSwr_ctx)
-                swr_free(&pSwr_ctx);
             pSwr_ctx = swr_alloc_set_opts(nullptr, MS->wanted_frame->channel_layout,
                                          (AVSampleFormat)MS->wanted_frame->format,
                                          MS->wanted_frame->sample_rate,
@@ -237,11 +208,14 @@ int PlayThread::audio_decode_frame(mediaState* MS, uint8_t* audio_buf)
             if (len2 < 0)
                 break;
 
-            av_free_packet(&packet);
-            return MS->wanted_frame->channels * len2 * av_get_bytes_per_sample((AVSampleFormat)MS->wanted_frame->format);
+            returns = MS->wanted_frame->channels * len2 * av_get_bytes_per_sample((AVSampleFormat)MS->wanted_frame->format);
         }
+        break;
     }
-    return -1;
+    swr_free(&pSwr_ctx);
+    av_frame_free(&pframe);
+    av_packet_unref(&packet);
+    return returns;
 }
 
 
@@ -309,9 +283,9 @@ int PlayThread::getMsDuration()				//获得毫秒为度量的总长度
 }
 
 
-int  PlayThread::getCurrentTime() 
+qint64  PlayThread::getCurrentTime() 
 { 
-	return static_cast<int>(m_MS.audio_clock); 
+	return m_MS.audio_clock; 
 }
 
 bool PlayThread::getIsDeviceInit() 
@@ -965,7 +939,7 @@ quint64 MusicPlayer::duration()
 }
 
 //获得当总位置（单位 毫秒）
-quint64 MusicPlayer::position()
+qint64 MusicPlayer::position()
 {
     return m_position;
 }

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -390,10 +390,10 @@ bool PlayThread::initDeviceAndFfmpegContext()
 	{
 		//读取音频的专辑图片
 		// read the format headers
-		if (pFormatCtx->iformat->read_header(pFormatCtx) < 0) {
-			printf("No header format");
-			//return;
-		}
+//		if (pFormatCtx->iformat->read_header(pFormatCtx) < 0) {
+//			printf("No header format");
+//			//return;
+//		}
 
 		//读取专辑图片
 		picture = QPixmap();
@@ -541,7 +541,7 @@ void PlayThread::generateAudioDataLoop()
 
     //[注:由于ffmpeg版本原因，ffmpeg 4.0.1 版本，在重头播放1秒多时有噪音，经试验，调用 av_seek_frame 后则会间接消除该噪音]
     //[若 后面更改 ffmpeg版本，可尝试去掉 seekToPos(10); 看看会不会在 1秒多 出现噪音]
-    seekToPos(10);
+//    seekToPos(10);
 
     AVPacket packet;
 

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -565,9 +565,7 @@ void PlayThread::generateAudioDataLoop()
             }
             else
             {
-                int curTime = getCurrentTime()*0.001;
-                int durat = getDuration()*0.000001;
-                if(curTime >= durat)//播放到尾端
+                if(m_MS.audioq.first_pkt == nullptr)//播放到尾端
                 {
                     qDebug() << "ending reached";
                     AGStatus = AGS_FINISH;

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -557,10 +557,6 @@ void PlayThread::generateAudioDataLoop()
                AVRational aVRational = {1, 1000};
                int64_t res = av_rescale_q(millisecondToSeek ,aVRational,pFormatCtx->streams[audioStream]->time_base);
 
-//               不要直接调SDL_PauseAudio()，避免相应的信号发不出去
-//               SDL_PauseAudio(1);
-               pauseDevice();
-
                //block here
                if (av_seek_frame(m_MS.fct, audioStream, res, AVSEEK_FLAG_ANY) < 0)
                {

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -565,6 +565,11 @@ void PlayThread::generateAudioDataLoop()
                {
                    //printf("Error to seek audio frame.\n");
                    qDebug()<<"seek error";
+                   emit seekError();
+
+                   AGStatus = AGS_FINISH;
+                   isEndByForce = true;
+                   break;
                }
                else
                {
@@ -741,6 +746,7 @@ MusicPlayer::MusicPlayer(QObject* parent):QObject(parent),m_volume(128)
         emit positionChanged(0); // 最后触发一次 BottomWidget::positionChanged，如果是单曲播放，则可达到进度条清零的效果
     });
     connect(playThread, &PlayThread::seekFinished, [&](){emit seekFinished();});
+    connect(playThread, &PlayThread::seekError, [&](){emit seekError();});
     connect(playThread, &PlayThread::volumeChanged,[=](uint8_t volume){
         emit volumeChanged(volume);}
     );

--- a/Entities/MusicPlayer/musicPlayer.cpp
+++ b/Entities/MusicPlayer/musicPlayer.cpp
@@ -572,6 +572,11 @@ void PlayThread::generateAudioDataLoop()
                {
                    logAudio = true;
                    qDebug()<<"seek successful  " << "  from " << m_MS.audio_clock << " to :";
+
+                   // When the player is paused, the new position should be sent on time.
+                   m_MS.audio_clock = millisecondToSeek;
+                   emit positionChanged();
+
                    if (audioStream!=-1) //audio
                    {
                     avcodec_flush_buffers(pCodecCtx);
@@ -579,9 +584,6 @@ void PlayThread::generateAudioDataLoop()
                        packet_queue_flush(&m_MS.audioq); //清除队列
                    }
                }
-//               不要直接调SDL_PauseAudio()，避免相应的信号发不出去
-//               SDL_PauseAudio(0);
-               playDevice();
 
                 AGStatus = AGS_PLAYING;
         }
@@ -895,8 +897,6 @@ void MusicPlayer::seek(quint64 pos)
     }
 
 	playThread->seekToPos(pos);
-
-    //#TODO 之后是否需要添加：暂停时seek后继续暂停
 }
 
 //往后跳（单位 毫秒）

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -140,6 +140,7 @@ signals:
     void audioPlay();               //播放
     void audioPause();              //暂停
     void audioFinish(bool isEndByForce);
+    void seekFinished();            //seek 完毕
     void volumeChanged(uint8_t);    //音量发生改变
     void durationChanged(qint64);   //总长发生改变（单位 微秒 10e-6）
     void errorOccur(int errorCode, QString errorMessage);
@@ -258,6 +259,7 @@ signals:
     void audioFinish(bool isEndByForce );   //播放完毕
     void durationChanged(qint64);           //总长发生改变（单位 毫秒）
     void positionChanged(qint64);              //位置发生改变（单位 毫秒）
+    void seekFinished();                    //seek 完毕
     void volumeChanged(int);                //音量大小发生改变，范围 0-128
     void errorOccur(int errorCode, QString msg);   //发生错误
 

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -141,6 +141,7 @@ signals:
     void audioPause();              //暂停
     void audioFinish(bool isEndByForce);
     void seekFinished();            //seek 完毕
+    void seekError();               //seek error
     void volumeChanged(uint8_t);    //音量发生改变
     void durationChanged(qint64);   //总长发生改变（单位 微秒 10e-6）
     void errorOccur(int errorCode, QString errorMessage);
@@ -260,6 +261,7 @@ signals:
     void durationChanged(qint64);           //总长发生改变（单位 毫秒）
     void positionChanged(qint64);              //位置发生改变（单位 毫秒）
     void seekFinished();                    //seek 完毕
+    void seekError();                       //seek error
     void volumeChanged(int);                //音量大小发生改变，范围 0-128
     void errorOccur(int errorCode, QString msg);   //发生错误
 

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -87,7 +87,7 @@ typedef struct{
 	AVStream *vStream;
     PacketQueue audioq; //音频队列
 
-    double audio_clock; //储存毫秒时间
+    qint64 audio_clock; //储存毫秒时间
     uint8_t volume;
 
     PlayThread* playThread;
@@ -127,7 +127,7 @@ public:
 	void setVolume(int value);
 
 	int getMsDuration();//获得毫秒为度量的总长度	
-	int getCurrentTime(); //获得当前毫秒时间
+	qint64 getCurrentTime(); //获得当前毫秒时间
 
 	bool getIsDeviceInit();//实现互斥访问 isDeviceInit 的接口
 
@@ -257,7 +257,7 @@ signals:
     void audioPause();                      //暂停
     void audioFinish(bool isEndByForce );   //播放完毕
     void durationChanged(qint64);           //总长发生改变（单位 毫秒）
-    void positionChanged(int);              //位置发生改变（单位 毫秒）
+    void positionChanged(qint64);              //位置发生改变（单位 毫秒）
     void volumeChanged(int);                //音量大小发生改变，范围 0-128
     void errorOccur(int errorCode, QString msg);   //发生错误
 
@@ -290,7 +290,7 @@ public slots:
     void setVolume(int volume);  //音量大小范围 0-128
     int getVolume();
     quint64 duration();  //获得当总时长（单位 毫秒）
-    quint64 position();  //获得当总位置（单位 毫秒）
+    qint64 position();  //获得当总位置（单位 毫秒）
 
     void setNotifyInterval(int msec);   //设置通知间隔（歌曲位置进度）
     Status state();
@@ -310,7 +310,7 @@ private:
 
 private:
     QString musicPath;
-    quint64 m_position;              //当前时间（单位 毫秒）
+    qint64 m_position;              //当前时间（单位 毫秒）
 
     int m_volume;
 

--- a/Entities/MusicPlayer/musicPlayer.h
+++ b/Entities/MusicPlayer/musicPlayer.h
@@ -144,6 +144,7 @@ signals:
     void seekError();               //seek error
     void volumeChanged(uint8_t);    //音量发生改变
     void durationChanged(qint64);   //总长发生改变（单位 微秒 10e-6）
+    void positionChanged();         //位置发生改变
     void errorOccur(int errorCode, QString errorMessage);
 
     void albumFound(QString);       //发现信息
@@ -296,14 +297,11 @@ public slots:
     quint64 duration();  //获得当总时长（单位 毫秒）
     qint64 position();  //获得当总位置（单位 毫秒）
 
-    void setNotifyInterval(int msec);   //设置通知间隔（歌曲位置进度）
     Status state();
 
 private slots:
     void sendPosChangedSignal();
     void onErrorOccurs(int ,QString);
-    void onStartTimer();
-    void onStopTimer();
 
 private:
     //歌曲文件信息
@@ -317,9 +315,6 @@ private:
     qint64 m_position;              //当前时间（单位 毫秒）
 
     int m_volume;
-
-    QTimer  m_positionUpdateTimer;    //通知歌曲进度发生改变的Timer
-    int     m_interval;               //间隔，单位毫秒
 
     PlayThread* playThread;
 


### PR DESCRIPTION

## 简述

本 PR 重写了`BesSlider`和相关界面逻辑，解决了播放进度条在使用上的主要问题。本 PR 还修改了部分播放逻辑，试图让程序运行得更好（properly）。

本 PR 试图解决 #12 、 #13 、 #15 、 #16 、 #17 、 #19 、 #20 、 #21 、 #23 、 #31 、 #32 、 #38 、 #39 、 #41 和 #42 中提到或遗留的问题。

本 PR 在 Ubuntu 18.04 / Windows 10 1903 / macOS 10.15<sup><a name="id394062" href="#ftn.id394062">\[1\]</a></sup> 测试通过。

## 详细内容

### 1. 移除前 2 秒的噪音

来自 #41 。

### 2. 不初始化`SDL_INIT_TIMER`和`SDL_INIT_VIDEO`子系统

来自 #42 。

### 3. 判定音频到达尾部的更好的方法

在 https://github.com/BensonLaur/Beslyric-for-X/pull/38#issuecomment-552202094 提到。

### 4. 移除 1 亿（1e8）次尝试并修改了`audio_decode_frame()`和`packet_queue_get()`中的逻辑

在 #23 和 #38 提到。
本 PR 对于 #23 和 #38 的解决不完全，特别是 https://github.com/BensonLaur/Beslyric-for-X/pull/38#issuecomment-554613738 提到的问题，这可能需要重新设计`PlayThread`。

#### 4.1. 移除 1 亿（1e8）次尝试

对于音频是否到达尾部有更好的方法，见上文。

#### 4.2. 修改`audio_decode_frame()`和`packet_queue_get()`

这部分修改是以我自己的理解来做的，目的是修 BUG，并且让逻辑更清楚。但目前我还没有掌握 FFmpeg 的基本用法，所以可能有不合理之处。

- 如果`PacketQueue`的第一个`AVPacket`包是`nullptr`，同时`block`置为`false`，那么`packet_queue_get()`将会返回`-1`。
- 除非重采样（SWR 相关）进行顺利，返回正确的音频数据，其他情况下，`audio_decode_frame()`都将返回`-1`。
- 现在，`m_MS.audio_clock`将以`qint64`类型存储当前音频位置的**毫秒**时间。相关的方法的形参类型、返回值类型也做了修改，但尽量把影响控制在最小范围——数据类型的统一之后再说。

### 5. 使用新的`BesSlider`并对`BottomWidget`和`MusicPlayer`做适配

由 #32 改良。

#### 5.1. 新的`BesSlider`

- 点击 = 在手柄上点击
  - 当鼠标点击并拖动手柄时，鼠标与手柄中心的相对位置将会被计算并存储到`click_pos_offset`，这样，手柄就会相对于鼠标保持一定的偏移量进行运动，而不是把自己的中心放到鼠标下方。这是 网易云音乐 的风格。
- 点击 = 在手柄以外的地方点击
  - 使用`BesSliderStyle`改变定位方式，原来是“步进”，现在是“直接”。
  - 新的定位方式将会使“点击并拖动”操作能够正确执行，因为在点击时`QSlider::sliderPressed`、`QSlider::sliderMoved`和`QSlider::sliderReleased`信号将会被正确地发送。
- “我的鼠标在哪儿？”
  - 使用`subControlRect`确定手柄的范围，进而确定鼠标是否在手柄上。
  - 包括`enterEvent(QEvent*)`和`leaveEvent(QEvent*)`方法在内的旧逻辑被移除了。
  - 设置`setMouseTracking(true)`。当`enableMouseEvt`置为`true`时，无论鼠标是否按下，当鼠标悬停在手柄上时，它的指针样式都将为`Qt::PointingHandCursor`，否则将为`Qt::ArrowCursor`（由`unsetCursor()`设置）。

#### 5.2. 对`BottomWidget`和`MusicPlayer`做适配

- 关于优化的逻辑
  - 即使仅仅是在手柄上做了一次点击（而不拖动），seek 操作也会被执行，所以移除了`audioOriginalPos`。这是 网易云音乐 的风格。
  - 现有的逻辑限制了仅当`enableMouseEvt`置为`true`时对`sliderSong`的点击才有效，所以冗余的判断被移除了。
- 正在播放的音频的位置
  - 当`sliderSong`被按下时，`AdjustingPos`将被置为`true`。
  - 当 seek 操作完成或出错时，`MusicPlayer`将会通过信号`MusicPlayer::seekFinished()`和`MusicPlayer::seekError()`通知`BottomWidget`，`AdjustingPos`将被置为`false`。
  - 这样能保证仅当没有鼠标操作作用于`sliderSong`时，音频的当前位置才能被`MusicPlayer`刷新。

### 6. 移除`m_positionUpdateTimer`并通过`audio_decode_frame()`发出位置变化的信号

- 任何 interval 的值都不是合理的，过高的值会发送太多相同的音频位置，而太低的值会让位置不准确。
- 现在，当`PlayThread::audio_decode_frame()`被调用时，`PlayThread`将会提醒`MusicPlayer`以发送新的音频位置。
- `PlayThread::positionChanged()`信号不包含当前位置的值。
- 当`MusicPlayer`收到`PlayThread::positionChanged()`信号时，`MusicPlayer::sendPosChangedSignal()`方法将会被调用。
- `MusicPlayer::positionChanged(qint64)`信号包含了由`playThread->getCurrentTime()`获得的位置。
- `MusicPlayer::seek(quint64)`方法中关于定时器的操作是无用且有误导性的（在 #31 提到）。

### 7. 当`PlayThread`处于`AGS_SEEK`状态时不进行`pauseDevice()`和`playDevice()`

#### 7.1. 移除`pauseDevice()`

如果本身是在暂停状态下，这个调用就是多余的。

#### 7.2. 移除`playDevice()`

实现“暂停时 seek 后继续暂停”。

在暂停时，通过代码（programmatically）进行 seek 后，音频位置将会即时刷新。

### 8. 提供回退 seek

- 方法`av_seek_frame()`使用`AVSEEK_FLAG_ANY`方式进行 seek 时可能会出错，特别是 seek 到音频末尾附近时。
- 所以，播放器将尝试使用`AVSEEK_FLAG_BACKWARD`方式再 seek 一次。

## 脚注

<p>
1. <sup><a name="ftn.id394062" href="#id394062">^</a></sup> macOS 10.15 需要 #37 。
</p>
