### PR TITLE
在 Qt 5.8 以下版本中“实现”了 QMouseEvent::setLocalPos

### DIFF
--- a/BesWidgets/BesSlider.h
+++ b/BesWidgets/BesSlider.h
@@ -42,7 +42,12 @@ protected:
         qDebug()<<"BesSlider::mouseMoveEvent: "<<ev->pos();
 
         // 通过偏移计算 handle 的正确位置
-        //ev->setLocalPos(ev->pos() += click_pos_offset);//?没有该函数？
+#if QT_VERSION >= 0x050800
+        ev->setLocalPos(ev->pos() += click_pos_offset);
+#else
+        QMouseEvent new_ev(ev->type(), ev->pos() += click_pos_offset, ev->button(), ev->buttons(), ev->modifiers());
+        ev = &new_ev;
+#endif
 
         // 如果需要在 enableMouseEvt == false 时，鼠标移动到 handle 上也改变鼠标样式，就去掉关于 enableMouseEvt 的判断。
         if (enableMouseEvt && getHandleRect().contains(ev->pos())) {
@@ -92,7 +97,12 @@ protected:
             qDebug()<<"click_pos_offset:"<<click_pos_offset;
 
             //用 handle 中心点代替实际点击位置，避免在点击到 handle 非中心位置时移动 handle，使 handle 看起来是能在任何位置被拖动的
-            //ev->setLocalPos(center_of_handle);//?没有该函数？
+#if QT_VERSION >= 0x050800
+            ev->setLocalPos(center_of_handle);
+#else
+            QMouseEvent new_ev(ev->type(), center_of_handle, ev->button(), ev->buttons(), ev->modifiers());
+            ev = &new_ev;
+#endif
         }else{
             qDebug() << "handle not clicked";
 


### PR DESCRIPTION
在 Qt < 5.8.0 版本中，[`QMouseEvent`](https://doc.qt.io/qt-5/qmouseevent.html)没有[`setLocalPos`](https://github.com/qt/qtbase/blob/1e654450157ca422833d48c0faf4fe0836c3125f/src/gui/kernel/qevent.cpp#L412-L422)成员方法。为了实现相同效果，构造一个新的`QMouseEvent`并让传入的参数`ev`指向它。由于新的`QMouseEvent`在栈上，所以**似乎**不用考虑内存管理的问题。

---

完整讨论：https://github.com/BensonLaur/Beslyric-for-X/pull/47#pullrequestreview-344947659
这是 78c4d786a5747bb5dd6e1c090d2911d0e637a206 的补丁。