### PR TITLE
修改 qmake 配置以优化构建输出文件的结构

### DIFF
--- a/Beslyric-for-X.pro
+++ b/Beslyric-for-X.pro
@@ -74,3 +74,33 @@ RC_FILE = Beslyric.rc
 macx{
 ICON = Beslyric.icns
 }
+
+# https://stackoverflow.com/questions/3440387/how-to-put-generated-files-e-g-object-files-into-a-separate-folder-when-using
+# 中间文件都放在 <conf>_generated 下，生成的二进制文件放在 <conf>_output 下
+
+CONFIG(debug, debug|release) {
+    OBJECTS_DIR = $$OUT_PWD/debug_generated
+    MOC_DIR = $$OUT_PWD/debug_generated
+    RCC_DIR = $$OUT_PWD/debug_generated
+
+    DESTDIR = $$OUT_PWD/debug_output
+}
+CONFIG(release, debug|release) {
+    OBJECTS_DIR = $$OUT_PWD/release_generated
+    MOC_DIR = $$OUT_PWD/release_generated
+    RCC_DIR = $$OUT_PWD/release_generated
+
+    DESTDIR = $$OUT_PWD/release_output
+}
+
+win32 {
+
+# https://stackoverflow.com/questions/28993418/qt-creator-creates-both-a-debug-and-a-release-folder-inside-the-designated-debug
+# https://stackoverflow.com/questions/1298988/qt-does-not-create-output-files-in-debug-release-folders-in-linux
+
+    message(old CONFIG = $$CONFIG)
+    CONFIG -= debug_and_release debug_and_release_target
+
+}
+
+message(CONFIG = $$CONFIG)


### PR DESCRIPTION
拆分自 #35 。

## 内容

### 1. 取消`debug_and_release`和`debug_and_release_target`

取消 win32 平台的 Qt 默认设置的`debug_and_release`和`debug_and_release_target` 标志，以避免在 Debug 和 Release 构建目录下再分别生成 Makefile.Debug、Makefile.Release 文件和 Debug、Release 目录，造成混乱。

目录结构改变前：

```
root
|- build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Debug
|  |- Debug
|  |  |- moc_
|  |  |- .obj
|  |  |- .res
|  |   \ Beslyric-for-X.exe
|  |- Release
|  |   \ <empty>
|  |- Makefile
|  |- Makefile.Debug
|   \ Makefile.Release
 \ build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Release
   |- Debug
   |  \ <empty>
   |- Release
   |  |- moc_
   |  |- .obj
   |  |- .res
   |   \ Beslyric-for-X.exe
   |- Makefile
   |- Makefile.Debug
    \ Makefile.Release
```

目录结构改变后：

```
root
|- build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Debug
|  |- moc_
|  |- .obj
|  |- .res
|  |- Beslyric-for-X.exe
|   \ Makefile
 \ build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Release
   |- moc_
   |- .obj
   |- .res
   |- Beslyric-for-X.exe
    \ Makefile
```

- [c++ - Qt Creator creates both a debug and a release folder inside the designated debug folder - Stack Overflow](https://stackoverflow.com/questions/28993418/qt-creator-creates-both-a-debug-and-a-release-folder-inside-the-designated-debug)
- [Qt does not create output files in debug/release folders in Linux - Stack Overflow](https://stackoverflow.com/questions/1298988/qt-does-not-create-output-files-in-debug-release-folders-in-linux)

### 2. 调整输出目录的结构

`Makefile`置于`$$OUT_PWD`，中间文件（.obj、.res、moc_）置于`$$OUT_PWD/<conf>_generated`，生成的二进制文件置于`$$OUT_PWD/<conf>_output`，使输出目录更整洁（`<conf>`指`debug`或`release`）。

- [How to put generated files (e.g. object files) into a separate folder when using Qt/qmake? - Stack Overflow](https://stackoverflow.com/questions/3440387/how-to-put-generated-files-e-g-object-files-into-a-separate-folder-when-using)
- [DESTDIR # Variables | qmake Manual](https://doc.qt.io/qt-5/qmake-variable-reference.html#destdir)

## 注意

“内容”部分描述的修改，与 PR 包含的提交的修改的顺序是不同的，所以，最终的输出目录的结构如下：

```
root
|- build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Debug
|  |- debug_generated
|  |  |- moc_
|  |  |- .obj
|  |   \ .res
|  |- debug_output
|  |  |- Beslyric-for-X.exe
|  |  |- Beslyric-for-X.ilk
|  |   \ Beslyric-for-X.pdb
|   \ Makefile
 \ build-Beslyric-for-X-Desktop_Qt_5_9_8_MSVC2015_32bit-Release
   |- release_generated
   |  |- moc_
   |  |- .obj
   |   \ .res
   |- release_output
   |   \ Beslyric-for-X.exe
    \ Makefile
```